### PR TITLE
Improvements to vclock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ name = "test"
 path = "test/test.rs"
 
 [dependencies]
-bincode = "0.9"
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/examples/pprint.rs
+++ b/examples/pprint.rs
@@ -1,15 +1,15 @@
 extern crate crdts;
 
-use crdts::{CmRDT};
+use crdts::*;
 
 fn main() {
-    let mut vclock = crdts::VClock::new();
-    let _ = vclock.witness(31231, 2);
-    let _ = vclock.witness(4829, 9);
-    let _ = vclock.witness(87132, 32);
+    let mut vclock = VClock::new();
+    let _ = vclock.apply_dot(Dot::new(31231, 2));
+    let _ = vclock.apply_dot(Dot::new(4829, 9));
+    let _ = vclock.apply_dot(Dot::new(87132, 32));
     println!("vclock:\t{}", vclock);
 
-    let mut reg = crdts::MVReg::<String, u128>::new();
+    let mut reg = MVReg::<String, u128>::new();
 
     let op1 = reg.set("some val", reg.read().derive_add_ctx(9742820));
     let op2 = reg.set("some other val", reg.read().derive_add_ctx(648572));

--- a/examples/reset_remove.rs
+++ b/examples/reset_remove.rs
@@ -1,0 +1,64 @@
+extern crate crdts;
+
+use crdts::{CvRDT, CmRDT, Map, Orswot};
+
+fn main() {
+    let mut friend_map: Map<String, Orswot<String, u8>, u8> = Map::new();
+    let add_ctx = friend_map.len()
+        .derive_add_ctx(1);
+
+    {
+        let op = friend_map.update(
+            "bob",
+            add_ctx,
+            |set, ctx| set.add("janet", ctx)
+        );
+        friend_map.apply(&op);
+    }
+
+    let mut friend_map_on_2nd_device = friend_map.clone();
+    // the map on the 2nd devices adds to `bob`'s friend set
+    {
+        let device2_add_ctx = friend_map_on_2nd_device
+            .len()
+            .derive_add_ctx(2);
+        let op = friend_map_on_2nd_device.update(
+            "bob",
+            device2_add_ctx,
+            |set, c| set.add("erik", c)
+        );
+        friend_map_on_2nd_device.apply(&op);
+    }
+    // Meanwhile, the map on the first device removes
+    // the entire 'bob' entry from the friend map.
+    {
+        let rm_ctx = friend_map
+            .get(&"bob".to_string())
+            .derive_rm_ctx();
+        friend_map.rm("bob", rm_ctx);
+    }
+
+    // once these two devices synchronize...
+    friend_map.merge(&friend_map_on_2nd_device);
+    friend_map_on_2nd_device.merge(&friend_map);
+    assert_eq!(friend_map, friend_map_on_2nd_device);
+    
+    // ... we see that "bob" is present but only
+    // contains `erik`.
+    //
+    // This is because the `erik` entry was not
+    // seen by the first device when it deleted
+    // the entry.
+
+    let bobs_friends: Vec<_> = friend_map   // Map<String, Orswot>
+        .get(&"bob".to_string()).val // Option<Orswot>
+        .unwrap()                    // Orswot
+        .read().val                  // HashSet
+        .into_iter()                 // Iter<Item=String>
+        .collect();                  // Vec<String>
+
+    assert_eq!(
+        bobs_friends,
+        vec!["erik".to_string()]
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,44 +40,6 @@ pub mod error;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
-extern crate bincode;
 
-use bincode::{Infinite, deserialize, serialize};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-
-/// Dumps this type to binary.
-///
-/// # Examples
-///
-/// ```
-/// use crdts::{Orswot, CmRDT, to_binary, from_binary};
-/// let mut a: Orswot<u8, u8> = Orswot::new();
-/// let op = a.add(1, a.value().derive_add_ctx(1));
-/// a.apply(&op);
-/// let encoded = to_binary(&a);
-/// let decoded = from_binary(encoded).unwrap();
-/// assert_eq!(a, decoded);
-/// ```
-pub fn to_binary<A: Serialize>(s: &A) -> Vec<u8> {
-    serialize(s, Infinite).unwrap()
-}
-
-/// Attempts to reconstruct a type from binary.
-///
-/// # Examples
-///
-/// ```
-/// use crdts::{Orswot, CmRDT, to_binary, from_binary};
-/// let mut a: Orswot<u8, u8> = Orswot::new();
-/// let op = a.add(1, a.value().derive_add_ctx(1));
-/// a.apply(&op);
-/// let encoded = to_binary(&a);
-/// let decoded = from_binary(encoded).unwrap();
-/// assert_eq!(a, decoded);
-/// ```
-pub fn from_binary<A: DeserializeOwned>(
-    encoded: Vec<u8>,
-) -> bincode::Result<A> {
-    deserialize(&encoded[..])
-}

--- a/src/mvreg.rs
+++ b/src/mvreg.rs
@@ -34,7 +34,7 @@ impl<T: Debug + Clone + Send + Serialize + DeserializeOwned> Val for T {}
 /// assert_eq!(read_ctx.val, vec!["bob".to_string(), "alice".to_string()]);
 /// assert_eq!(
 ///     read_ctx.add_clock,
-///     vec![(123, 1), (111, 1)]
+///     vec![Dot::new(123, 1), Dot::new(111, 1)]
 ///       .into_iter()
 ///       .collect()
 /// );

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -3,10 +3,11 @@
 //! # Examples
 //!
 //! ```
-//! use crdts::VClock;
-//! let (mut a, mut b) = (VClock::new(), VClock::new());
-//! a.witness("A".to_string(), 2);
-//! b.witness("A".to_string(), 1);
+//! use crdts::*;
+//! let mut a = VClock::new();
+//! let mut b = VClock::new();
+//! a.apply_dot(Dot::new("A".to_string(), 2));
+//! b.apply_dot(Dot::new("A".to_string(), 1));
 //! assert!(a > b);
 //! ```
 
@@ -19,10 +20,7 @@ use std::cmp::{self, Ordering};
 use std::collections::{BTreeMap, btree_map};
 use std::hash::Hash;
 
-/// A counter is used to track causality at a particular actor.
-pub type Counter = u64;
-
-/// Common Actor type, Actors are unique identifier for every `thing` mutating a VClock.
+/// Common Actor type. Actors are unique identifier for every `thing` mutating a VClock.
 /// VClock based CRDT's will need to expose this Actor type to the user.
 pub trait Actor: Ord + Clone + Hash + Send + Serialize + DeserializeOwned + Debug {}
 impl<A: Ord + Clone + Hash + Send + Serialize + DeserializeOwned + Debug> Actor for A {}
@@ -35,10 +33,15 @@ pub struct Dot<A: Actor> {
     /// The actor identifier
     pub actor: A,
     /// The current version of this actor
-    pub counter: Counter
+    pub counter: u64
 }
 
-// TODO: VClock derives an Ord implementation, but a total order over VClocks doesn't exist. I think this may mess up our BTreeMap usage in ORSWOT and friends
+impl<A: Actor> Dot<A> {
+    /// Build a Dot from an actor and counter
+    pub fn new(actor: A, counter: u64) -> Self {
+        Dot { actor, counter }
+    }
+}
 
 /// A `VClock` is a standard vector clock.
 /// It contains a set of "actors" and associated counters.
@@ -53,7 +56,7 @@ pub struct Dot<A: Actor> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct VClock<A: Actor> {
     /// dots is the mapping from actors to their associated counters
-    pub dots: BTreeMap<A, Counter>,
+    pub dots: BTreeMap<A, u64>,
 }
 
 impl<A: Actor> PartialOrd for VClock<A> {
@@ -86,16 +89,16 @@ impl<A: Actor + Display> Display for VClock<A> {
 impl<A: Actor> Causal<A> for VClock<A> {
     /// Truncates to the greatest-lower-bound of the given VClock and self
     /// ``` rust
-    /// use crdts::{VClock, Causal};
+    /// use crdts::*;
     /// let mut c = VClock::new();
-    /// c.witness(23, 6);
-    /// c.witness(89, 14);
+    /// c.apply_dot(Dot::new(23, 6));
+    /// c.apply_dot(Dot::new(89, 14));
     /// let c2 = c.clone();
     ///
     /// c.truncate(&c2); // should be a no-op
     /// assert_eq!(c, c2);
     ///
-    /// c.witness(43, 1);
+    /// c.apply_dot(Dot::new(43, 1));
     /// assert_eq!(c.get(&43), 1);
     /// c.truncate(&c2); // should remove the 43 => 1 entry
     /// assert_eq!(c.get(&43), 0);
@@ -124,14 +127,14 @@ impl<A: Actor> CmRDT for VClock<A> {
     type Op = Dot<A>;
 
     fn apply(&mut self, dot: &Self::Op) {
-        let _ = self.witness(dot.actor.clone(), dot.counter);
+        self.apply_dot(dot.clone());
     }
 }
 
 impl<A: Actor> CvRDT for VClock<A> {
     fn merge(&mut self, other: &VClock<A>) {
         for (actor, counter) in other.dots.iter() {
-            let _ = self.witness(actor.clone(), *counter);
+            self.apply_dot(Dot::new(actor.clone(), *counter));
         }
     }
 }
@@ -142,42 +145,62 @@ impl<A: Actor> VClock<A> {
         VClock { dots: BTreeMap::new() }
     }
 
-    /// For a particular actor, possibly store a new counter
-    /// if it dominates.
+    /// Apply a Dot to this vclock.
     ///
     /// # Examples
-    ///
     /// ```
-    /// use crdts::VClock;
-    /// let (mut a, mut b) = (VClock::new(), VClock::new());
-    /// a.witness("A".to_string(), 2);
-    /// a.witness("A".to_string(), 0); // ignored because 2 dominates 0
-    /// b.witness("A".to_string(), 1);
-    /// assert!(a > b);
-    /// ```
+    /// use crdts::*;
+    /// let mut v = VClock::new();
     ///
-    pub fn witness(&mut self, actor: A, counter: Counter) {
-        if !(self.get(&actor) >= counter) {
-            self.dots.insert(actor, counter);
+    /// v.apply_dot(Dot::new("A".to_string(), 2));
+    /// 
+    /// // now all dots applied to `v` from actor `A` where
+    /// // the counter is not bigger than 2 are nops.
+    /// v.apply_dot(Dot::new("A".to_string(), 0));
+    /// assert_eq!(v.get(&"A".to_string()), 2);
+    /// ```
+    pub fn apply_dot(&mut self, dot: Dot<A>) {
+        if !(self.get(&dot.actor) >= dot.counter) {
+            self.dots.insert(dot.actor, dot.counter);
         }
     }
 
-    /// For a particular actor, increment the associated counter.
+    /// Immediately increment an actor's counter.
     ///
     /// # Examples
+    /// ```
+    /// use crdts::VClock;
+    /// let mut v = VClock::new();
     ///
+    /// v.apply_inc("A".to_string());
+    /// assert_eq!(v.get(&"A".to_string()), 1);
+    /// ```
+    pub fn apply_inc(&mut self, actor: A) {
+        let inc_counter = self.get(&actor) + 1;
+        self.apply_dot(Dot::new(actor, inc_counter));
+    }
+
+    /// Generate Op to increment an actor's counter.
+    ///
+    /// # Examples
     /// ```
     /// use crdts::{VClock, CmRDT};
-    /// let (mut a, mut b) = (VClock::new(), VClock::new());
-    /// let a_op1 = a.inc("A".to_string());
-    /// a.apply(&a_op1);
-    /// let a_op2 = a.inc("A".to_string());
-    /// a.apply(&a_op2);
+    /// let mut a = VClock::new();
     ///
-    /// a.witness("A".to_string(), 0); // ignored because 2 dominates 0
-    /// let b_op = b.inc("A".to_string());
-    /// b.apply(&b_op);
-    /// assert!(a > b);
+    /// // `a.inc()` does not mutate the vclock!
+    /// let op = a.inc("A".to_string());
+    /// assert_eq!(a, VClock::new());
+    ///
+    /// // we must apply the op to the VClock to have
+    /// // its edit take effect.
+    /// a.apply(&op);
+    /// assert_eq!(a.get(&"A".to_string()), 1);
+    ///
+    /// // Op's can be replicated to another node and
+    /// // applied to the local state there.
+    /// let mut other_node = VClock::new();
+    /// other_node.apply(&op);
+    /// assert_eq!(other_node.get(&"A".to_string()), 1);
     /// ```
     pub fn inc(&self, actor: A) -> Dot<A> {
         let next = self.get(&actor) + 1;
@@ -187,7 +210,6 @@ impl<A: Actor> VClock<A> {
     /// True if two vector clocks have diverged.
     ///
     /// # Examples
-    ///
     /// ```
     /// use crdts::{VClock, CmRDT};
     /// let (mut a, mut b) = (VClock::new(), VClock::new());
@@ -203,7 +225,7 @@ impl<A: Actor> VClock<A> {
 
     /// Return the associated counter for this actor.
     /// All actors not in the vclock have an implied count of 0
-    pub fn get(&self, actor: &A) -> Counter {
+    pub fn get(&self, actor: &A) -> u64 {
         self.dots.get(actor)
             .map(|counter| *counter)
             .unwrap_or(0)
@@ -242,38 +264,49 @@ impl<A: Actor> VClock<A> {
     }
 }
 
-impl<A: Actor> std::iter::IntoIterator for VClock<A> {
-    type Item = (A, u64);
-    type IntoIter = btree_map::IntoIter<A, u64>;
-    
-    /// Consumes the vclock and returns an iterator over dots in the clock
-    fn into_iter(self) -> btree_map::IntoIter<A, u64> {
-        self.dots.into_iter()
+/// Generated from calls to VClock::into_iter()
+pub struct IntoIter<A: Actor> {
+    btree_iter: btree_map::IntoIter<A, u64>
+}
+
+impl<A: Actor> std::iter::Iterator for IntoIter<A> {
+    type Item = Dot<A>;
+
+    fn next(&mut self) -> Option<Dot<A>> {
+        self.btree_iter
+            .next()
+            .map(|(actor, counter)| Dot::new(actor, counter))
     }
 }
 
-impl<A: Actor> std::iter::FromIterator<(A, u64)> for VClock<A> {
-    fn from_iter<I: IntoIterator<Item=(A, u64)>>(iter: I) -> Self {
-        let mut clock = Self::new();
+impl<A: Actor> std::iter::IntoIterator for VClock<A> {
+    type Item = Dot<A>;
+    type IntoIter = IntoIter<A>;
+    
+    /// Consumes the vclock and returns an iterator over dots in the clock
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            btree_iter: self.dots.into_iter()
+        }
+    }
+}
 
-        for (actor, counter) in iter {
-            let _ = clock.witness(actor, counter);
+impl<A: Actor> std::iter::FromIterator<Dot<A>> for VClock<A> {
+    fn from_iter<I: IntoIterator<Item=Dot<A>>>(iter: I) -> Self {
+        let mut clock = VClock::new();
+
+        for dot in iter {
+            clock.apply(&dot);
         }
 
         clock
     }
 }
 
-impl<A: Actor> From<Vec<(A, u64)>> for VClock<A> {
-    fn from(vec: Vec<(A, u64)>) -> Self {
-        vec.into_iter().collect()
-    }
-}
-
 impl<A: Actor> From<Dot<A>> for VClock<A> {
     fn from(dot: Dot<A>) -> Self {
         let mut clock = VClock::new();
-        clock.witness(dot.actor, dot.counter);
+        clock.apply(&dot);
         clock
     }
 }

--- a/test/mvreg.rs
+++ b/test/mvreg.rs
@@ -52,7 +52,9 @@ fn test_concurrent_update_with_same_value_dont_collapse_on_merge() {
     assert_eq!(read_ctx.val, vec![23, 23]);
     assert_eq!(
         read_ctx.add_clock,
-        VClock::from(vec![(4, 1), (7, 1)])
+        vec![Dot::new(4, 1), Dot::new(7, 1)]
+            .into_iter()
+            .collect()
     );
 }
 
@@ -74,7 +76,9 @@ fn test_concurrent_update_with_same_value_dont_collapse_on_apply() {
     assert_eq!(read_ctx.val, vec![23, 23]);
     assert_eq!(
         read_ctx.add_clock,
-        VClock::from(vec![(4, 1), (7, 1)])
+        vec![Dot::new(4, 1), Dot::new(7, 1)]
+            .into_iter()
+            .collect()
     );
 }
 
@@ -96,8 +100,7 @@ fn test_multi_val() {
     let read_ctx = r1.read();
     
     assert!(
-        read_ctx.val == vec![32, 82] ||
-            read_ctx.val == vec![82, 32]
+        read_ctx.val == vec![32, 82] || read_ctx.val == vec![82, 32]
     );
 }
 

--- a/test/orswot.rs
+++ b/test/orswot.rs
@@ -83,12 +83,12 @@ quickcheck! {
 #[test]
 fn weird_highlight_1() {
     let (mut a, mut b) = (Orswot::<u8, u8>::new(), Orswot::<u8, u8>::new());
-    let op_a = a.add(1, a.value().derive_add_ctx(1));
-    let op_b = b.add(2, b.value().derive_add_ctx(1));
+    let op_a = a.add(1, a.read().derive_add_ctx(1));
+    let op_b = b.add(2, b.read().derive_add_ctx(1));
     a.apply(&op_a);
     b.apply(&op_b);
     a.merge(&b);
-    assert!(a.value().val.is_empty());
+    assert!(a.read().val.is_empty());
 }
 
 ///
@@ -98,7 +98,7 @@ fn adds_dont_destroy_causality() {
     let mut b = a.clone();
     let mut c = a.clone();
 
-    let c_ctx = c.value();
+    let c_ctx = c.read();
 
     let add_op = c.add("element", c_ctx.derive_add_ctx(1));
     c.apply(&add_op);
@@ -112,22 +112,22 @@ fn adds_dont_destroy_causality() {
     // should descend from vclock { 1->1, 2->1 }
     assert_eq!(
         c_element_ctx.rm_clock,
-        vec![(1, 1), (2, 1)].into_iter().collect()
+        vec![Dot::new(1, 1), Dot::new(2, 1)].into_iter().collect()
     );
 
-    let a_add_ctx = a.value().derive_add_ctx(7);
+    let a_add_ctx = a.read().derive_add_ctx(7);
     let a_op1 = a.add("element", a_add_ctx);
     a.apply(&a_op1);
     b.apply(
         &c.remove("element", c_element_ctx.derive_rm_ctx())
     );
 
-    let a_op2 = a.add("element", a.value().derive_add_ctx(1));
+    let a_op2 = a.add("element", a.read().derive_add_ctx(1));
     a.apply(&a_op2);
 
     a.merge(&b);
     assert_eq!(
-        a.value().val,
+        a.read().val,
         vec!["element".to_string()].into_iter().collect()
     );
 }
@@ -140,13 +140,13 @@ fn merge_clocks_of_identical_entries() {
     let mut a = Orswot::<u8, u8>::new();
     let mut b = a.clone();
     // add element 1 with witnesses 3 and 7
-    let a_op = a.add(1, a.value().derive_add_ctx(3));
+    let a_op = a.add(1, a.read().derive_add_ctx(3));
     a.apply(&a_op);
-    let b_op = a.add(1, b.value().derive_add_ctx(7));
+    let b_op = a.add(1, b.read().derive_add_ctx(7));
     b.apply(&b_op);
     a.merge(&b);
     assert_eq!(
-        a.value().val,
+        a.read().val,
         vec![1].into_iter().collect()
     );
     let mut final_clock = VClock::new();
@@ -165,24 +165,24 @@ fn test_disjoint_merge() {
     let mut a = Orswot::<u8, u8>::new();
     let mut b = a.clone();
 
-    let a_op = a.add(0, a.value().derive_add_ctx(1));
+    let a_op = a.add(0, a.read().derive_add_ctx(1));
     a.apply(&a_op);
-    assert_eq!(a.value().val, vec![0].into_iter().collect());
+    assert_eq!(a.read().val, vec![0].into_iter().collect());
 
-    let b_op = b.add(1, b.value().derive_add_ctx(2));
+    let b_op = b.add(1, b.read().derive_add_ctx(2));
     b.apply(&b_op);
-    assert_eq!(b.value().val, vec![1].into_iter().collect());
+    assert_eq!(b.read().val, vec![1].into_iter().collect());
 
     let mut c = a.clone();
     c.merge(&b);
-    assert_eq!(c.value().val, vec![0, 1].into_iter().collect());
+    assert_eq!(c.read().val, vec![0, 1].into_iter().collect());
 
     let a_rm = a.remove(0, a.contains(&0).derive_rm_ctx());
     a.apply(&a_rm);
     let mut d = a.clone();
     d.merge(&c);
     assert_eq!(
-        d.value().val,
+        d.read().val,
         vec![1].into_iter().collect()
     );
 }
@@ -193,9 +193,9 @@ fn test_disjoint_merge() {
 #[test]
 fn test_no_dots_left_test() {
     let (mut a, mut b) = (Orswot::<u8, u8>::new(), Orswot::<u8, u8>::new());
-    let a_op = a.add(0, a.value().derive_add_ctx(1));
+    let a_op = a.add(0, a.read().derive_add_ctx(1));
     a.apply(&a_op);
-    let b_op = b.add(0, b.value().derive_add_ctx(2));
+    let b_op = b.add(0, b.read().derive_add_ctx(2));
     b.apply(&b_op);
     let c = a.clone();
     let a_rm = a.remove(0, a.contains(&0).derive_rm_ctx());
@@ -203,7 +203,7 @@ fn test_no_dots_left_test() {
 
     // replicate B to A, now A has B's 'Z'
     a.merge(&b);
-    assert_eq!(a.value().val, vec![0].into_iter().collect());
+    assert_eq!(a.read().val, vec![0].into_iter().collect());
 
     let mut expected_clock = VClock::new();
     let op_1 = expected_clock.inc(1);
@@ -211,22 +211,22 @@ fn test_no_dots_left_test() {
     expected_clock.apply(&op_1);
     expected_clock.apply(&op_2);
 
-    assert_eq!(a.value().add_clock, expected_clock);
+    assert_eq!(a.read().add_clock, expected_clock);
 
     let b_rm = b.remove(0, b.contains(&0).derive_rm_ctx());
     b.apply(&b_rm);
-    assert!(b.value().val.is_empty());
+    assert!(b.read().val.is_empty());
 
     // Replicate C to B, now B has A's old 'Z'
     b.merge(&c);
-    assert_eq!(b.value().val, vec![0].into_iter().collect());
+    assert_eq!(b.read().val, vec![0].into_iter().collect());
 
     // Merge everything, without the fix You end up with 'Z' present,
     // with no dots
     b.merge(&a);
     b.merge(&c);
 
-    assert!(b.value().val.is_empty());
+    assert!(b.read().val.is_empty());
 }
 
 // port from riak_dt
@@ -245,7 +245,7 @@ fn test_no_dots_left_test() {
 #[test]
 fn test_dead_node_update() {
     let mut a = Orswot::<u8, u8>::new();
-    let a_op = a.add(0, a.value().derive_add_ctx(1));
+    let a_op = a.add(0, a.read().derive_add_ctx(1));
     assert_eq!(
         a_op,
         Op::Add { dot: Dot { actor: 1, counter: 1 }, member: 0 }
@@ -257,13 +257,16 @@ fn test_dead_node_update() {
     );
 
     let mut b = a.clone();
-    let b_op = b.add(1, b.value().derive_add_ctx(2));
+    let b_op = b.add(1, b.read().derive_add_ctx(2));
     b.apply(&b_op);
-    let bctx = b.value();
-    assert_eq!(bctx.add_clock, vec![(1, 1), (2, 1)].into());
+    let bctx = b.read();
+    assert_eq!(
+        bctx.add_clock,
+        vec![Dot::new(1, 1), Dot::new(2, 1)].into_iter().collect()
+    );
     let rm_op = a.remove(0, bctx.derive_rm_ctx());
     a.apply(&rm_op);
-    assert_eq!(a.value().val, HashSet::new());
+    assert_eq!(a.read().val, HashSet::new());
 }
 
 #[test]
@@ -291,7 +294,7 @@ fn test_reset_remove_semantics() {
 
     assert_eq!(m1.get(&101).val, None);
     assert_eq!(
-        m2.get(&101).val.unwrap().value().val,
+        m2.get(&101).val.unwrap().read().val,
         vec![1, 2].into_iter().collect()
     );
 
@@ -301,7 +304,7 @@ fn test_reset_remove_semantics() {
 
     assert_eq!(m1, m2);
     assert_eq!(
-        m1.get(&101).val.unwrap().value().val,
+        m1.get(&101).val.unwrap().read().val,
         vec![2].into_iter().collect()
     );
 }


### PR DESCRIPTION
Add an `immediate` mode to VClock, ie. we have varients of all non-mutating (op-generating) functions that will mutate the vclock.

``` rust
// old
let mut vc = VClock::new();
let op = vc.inc("Actor 1".to_string())
vc.apply(&op);

// we've added `apply_*` variants to all op generating functions
let mut vc = VClock::new();
vc.apply_inc("Actor 1".to_string());
```

The plan is to add the same `apply_*` variants to the rest of the CRDT's in the library.

Also in this PR:
- we dropped our dependency on bincode, all CRDT's implement `serde` traits so there's no need for us to force a serialization format on the user.
- added a reset_remove example.