### PR TITLE
lib: misc cleanup

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,13 @@
 use std::{fmt, error, result};
 
 /// CRDT Result alias to reduce redundency in function return types
-pub type Result<T> = result::Result<T, Error>;
+pub(crate) type Result<T> = result::Result<T, Error>;
 
 /// Possible CRDT error codes
 #[derive(Debug, PartialEq)]
 pub enum Error {
     /// A conflicting change to a CRDT is witnessed by a dot that already exists.
+    ///
     /// We don't always check for this error case as it can be fairly expensive.
     /// Instead, users must design their system in a way that will make these
     /// dot collisions unlikely / impossible.

--- a/src/gset.rs
+++ b/src/gset.rs
@@ -1,12 +1,14 @@
 use std::collections::BTreeSet;
 
+use serde_derive::{Serialize, Deserialize};
+
 /// A `GSet` is a grow-only set.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct GSet<A: Ord + Serialize + DeserializeOwned> {
-    value: BTreeSet<A>,
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GSet<T: Ord> {
+    value: BTreeSet<T>,
 }
 
-impl<A: Ord + Serialize + DeserializeOwned> GSet<A> {
+impl<T: Ord> GSet<T> {
     /// Instantiates an empty `GSet`.
     pub fn new() -> Self {
         GSet { value: BTreeSet::new() }
@@ -25,7 +27,7 @@ impl<A: Ord + Serialize + DeserializeOwned> GSet<A> {
     /// assert!(a.contains(&1));
     /// assert!(a.contains(&2));
     /// ```
-    pub fn merge(&mut self, other: GSet<A>) {
+    pub fn merge(&mut self, other: GSet<T>) {
         other.value.into_iter()
             .for_each(|e| self.insert(e))
     }
@@ -40,7 +42,7 @@ impl<A: Ord + Serialize + DeserializeOwned> GSet<A> {
     /// a.insert(1);
     /// assert!(a.contains(&1));
     /// ```
-    pub fn insert(&mut self, element: A) {
+    pub fn insert(&mut self, element: T) {
         self.value.insert(element);
     }
 
@@ -54,7 +56,7 @@ impl<A: Ord + Serialize + DeserializeOwned> GSet<A> {
     /// a.insert(1);
     /// assert!(a.contains(&1));
     /// ```
-    pub fn contains(&self, element: &A) -> bool {
+    pub fn contains(&self, element: &T) -> bool {
         self.value.contains(element)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,44 +1,51 @@
-//! `crdts` is a library of thoroughly-tested, serializable CRDT's
-//! ported from the riak_dt library to rust.
+//! A pure-Rust library of thoroughly-tested, serializable CRDT's.
+//!
+//! [Conflict-free Replicated Data Types][crdt] (CRDTs) are data structures
+//! which can be replicated across multiple networked nodes, and whose
+//! properties allow for deterministic, local resolution of
+//! possible inconsistencies which might result from concurrent
+//! operations.
+//!
+//! [crdt]: https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type
 #![crate_type = "lib"]
 #![deny(missing_docs)]
 
-mod traits;
+mod error;
+pub use crate::error::Error;
 
-/// This module contains a Last-Write-Wins Register
+mod traits;
+pub use crate::traits::{CvRDT, CmRDT, Causal, FunkyCvRDT, FunkyCmRDT};
+
+/// This module contains a Last-Write-Wins Register.
 pub mod lwwreg;
 
-/// This module contains a Multi-Value Register
+/// This module contains a Multi-Value Register.
 pub mod mvreg;
 
-/// This module contains a Vector Clock
 pub mod vclock;
 
-/// This module contains an Observed-Remove Set with out tombstones
+/// This module contains an Observed-Remove Set With Out Tombstones.
 pub mod orswot;
 
-/// This module contains a Grow-only counter
+/// This module contains a Grow-only Counter.
 pub mod gcounter;
 
-/// This module contains a postive-negative counter
+/// This module contains a Positive-Negative Counter.
 pub mod pncounter;
 
-/// This module contains a Map with Reset-Remove and Observed-Remove semantics
+/// This module contains a Map with Reset-Remove and Observed-Remove semantics.
 pub mod map;
 
-/// This module contains context for editing a CRDT
+/// This module contains context for editing a CRDT.
 pub mod ctx;
-mod error;
 
+// Top-level re-exports for CRDT structures.
 pub use crate::{
-    error::Error,
     gcounter::GCounter,
     lwwreg::LWWReg,
+    map::Map,
     mvreg::MVReg,
     orswot::Orswot,
     pncounter::PNCounter,
-    map::Map,
-    ctx::{ReadCtx, AddCtx, RmCtx},
-    vclock::{VClock, Dot, Actor},
-    traits::{CvRDT, CmRDT, Causal, FunkyCvRDT, FunkyCmRDT}
+    vclock::{Dot, VClock},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@ pub mod orswot;
 /// This module contains a Grow-only Counter.
 pub mod gcounter;
 
+/// This module contains a Grow-only Set.
+pub mod gset;
+
 /// This module contains a Positive-Negative Counter.
 pub mod pncounter;
 
@@ -42,6 +45,7 @@ pub mod ctx;
 // Top-level re-exports for CRDT structures.
 pub use crate::{
     gcounter::GCounter,
+    gset::GSet,
     lwwreg::LWWReg,
     map::Map,
     mvreg::MVReg,

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -1,8 +1,4 @@
-//! The `orswot` crate provides an implementation of the addition-biased OR-Set
-//! without tombstones (ORSWOT).  Ported directly from riak_dt.
-//!
-//! # Examples
-//!
+/// Observed-Remove Set With Out Tombstones (ORSWOT), ported directly from `riak_dt`.
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,13 +2,13 @@ use std::fmt::Debug;
 
 use crate::vclock::{VClock, Actor};
 
-/// State based CRDT's replicate by transmitting the entire CRDT state
+/// State based CRDT's replicate by transmitting the entire CRDT state.
 pub trait CvRDT {
     /// Merge the given CRDT into the current CRDT.
     fn merge(&mut self, other: &Self);
 }
 
-/// Operation based CRDT's replicate with ops
+/// Operation based CRDT's replicate by transmitting each operation.
 pub trait CmRDT {
     /// Op defines a mutation to the CRDT.
     /// As long as Op's from one actor are replayed in exactly the same order they
@@ -37,13 +37,14 @@ pub trait CmRDT {
     fn apply(&mut self, op: &Self::Op);
 }
 
-/// Crdt's are causal if they are built on top of vector clocks
+/// CRDT's are causal if they are built on top of vector clocks.
 pub trait Causal<A: Actor> {
     /// Truncate the CRDT to remove anything before the clock
     fn truncate(&mut self, clock: &VClock<A>);
 }
 
-/// Funky variant of the CvRDT
+/// Funky variant of the `CvRDT` trait.
+///
 /// This trait is for CvRDT's whose state space can't be easily encoded in rusts
 /// typesystem so we rely on runtime error checking.
 /// E.g. the unicity of timestamp assumption in LWWReg
@@ -56,7 +57,8 @@ pub trait FunkyCvRDT {
 }
 
 
-/// Funky variant of the CmRDT
+/// Funky variant of the `CmRDT` trait.
+///
 /// This trait is for CvRDT's whose state space can't be easily encoded in rusts
 /// typesystem so we rely on runtime error checking.
 /// E.g. the unicity property of timestamp assumption in LWWReg

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -1,9 +1,10 @@
-//! The `vclock` crate provides a generic vector clock implementation.
+//! This module contains a generic Vector Clock implementation.
 //!
 //! # Examples
 //!
 //! ```
-//! use crdts::*;
+//! use crdts::{Dot, VClock};
+//!
 //! let mut a = VClock::new();
 //! let mut b = VClock::new();
 //! a.apply_dot(Dot::new("A".to_string(), 2));


### PR DESCRIPTION
This contains a few assorted cleanups that I've accumulated when reading through the code on master:
 * `error::Result` is not exposed, thus changed visibility accordingly
 * several cosmetic docs fixes applied
 * `gset` module was not wired in, thus fixed and exported