### PR TITLE
Rename truncate to forget

### DIFF
--- a/examples/pprint.rs
+++ b/examples/pprint.rs
@@ -11,8 +11,8 @@ fn main() {
 
     let mut reg = MVReg::<String, u128>::new();
 
-    let op1 = reg.write("some val", reg.read().derive_add_ctx(9742820));
-    let op2 = reg.write("some other val", reg.read().derive_add_ctx(648572));
+    let op1 = reg.write("some val", reg.read().derive_add_ctx(9_742_820));
+    let op2 = reg.write("some other val", reg.read().derive_add_ctx(648_572));
     reg.apply(&op1);
     reg.apply(&op2);
 

--- a/src/gset.rs
+++ b/src/gset.rs
@@ -3,9 +3,15 @@ use std::collections::BTreeSet;
 use serde_derive::{Serialize, Deserialize};
 
 /// A `GSet` is a grow-only set.
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GSet<T: Ord> {
     value: BTreeSet<T>,
+}
+
+impl<T: Ord> Default for GSet<T> {
+    fn default() -> Self {
+        GSet::new()
+    }
 }
 
 impl<T: Ord> GSet<T> {

--- a/src/mvreg.rs
+++ b/src/mvreg.rs
@@ -89,12 +89,12 @@ impl<V: Val + PartialEq, A: Actor> PartialEq for MVReg<V, A> {
 impl<V: Val + Eq, A: Actor> Eq for MVReg<V, A> {}
 
 impl<V: Val, A: Actor> Causal<A> for MVReg<V, A> {
-    fn truncate(&mut self, clock: &VClock<A>) {
+    fn forget(&mut self, clock: &VClock<A>) {
         self.vals = self.vals.clone().into_iter()
             .filter_map(|(mut val_clock, val)| {
-                val_clock.subtract(&clock);
+                val_clock.forget(&clock);
                 if val_clock.is_empty() {
-                    None
+                    None // remove this value from the register
                 } else {
                     Some((val_clock, val))
                 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -39,8 +39,8 @@ pub trait CmRDT {
 
 /// CRDT's are causal if they are built on top of vector clocks.
 pub trait Causal<A: Actor> {
-    /// Truncate the CRDT to remove anything before the clock
-    fn truncate(&mut self, clock: &VClock<A>);
+    /// Forget data that is strictly smaller than this clock
+    fn forget(&mut self, clock: &VClock<A>);
 }
 
 /// Funky variant of the `CvRDT` trait.

--- a/test/mvreg.rs
+++ b/test/mvreg.rs
@@ -197,18 +197,18 @@ quickcheck! {
         TestResult::from_bool(true)
     }
 
-    fn prop_truncate(r_ops: Vec<(u8, u8)>) -> bool {
+    fn prop_forget(r_ops: Vec<(u8, u8)>) -> bool {
         let mut r = build_test_reg(r_ops).reg;
         let r_snapshot = r.clone();
 
         // truncating with the empty clock should be a nop
-        r.truncate(&VClock::new());
+        r.forget(&VClock::new());
         assert_eq!(r, r_snapshot);
 
         // truncating with the merge of all val clocks should give us
         // an empty register
         let clock = r.read().add_clock;
-        r.truncate(&clock);
+        r.forget(&clock);
         assert_eq!(r, MVReg::new());
         true
     }


### PR DESCRIPTION
I think forget encodes the behavior we expect better. I also changed the definition of truncate for
vclocks to be the same as what the `VClock::subtract` function did