### PR TITLE
Loosen trait bounds

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -30,10 +30,7 @@ impl error::Error for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::ConflictingMarker => {
-                use std::error::Error;
-                write!(f, "{}", self.description())
-            }
+            Error::ConflictingMarker => write!(f, "{}", self.to_string()),
         }
     }
 }

--- a/src/gset.rs
+++ b/src/gset.rs
@@ -1,7 +1,5 @@
-use std::collections::BTreeSet;
-use std::fmt::Debug;
-
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 use crate::traits::{CmRDT, CvRDT};
 
@@ -36,7 +34,7 @@ impl<T: Ord + Clone> CvRDT for GSet<T> {
     }
 }
 
-impl<T: Ord + Debug> CmRDT for GSet<T> {
+impl<T: Ord> CmRDT for GSet<T> {
     type Op = T;
 
     fn apply(&mut self, op: Self::Op) {

--- a/src/map.rs
+++ b/src/map.rs
@@ -260,12 +260,18 @@ impl<K: Ord, V: Val<A>, A: Actor> Map<K, V, A> {
         }
     }
 
-    /// Update a value under some key, if the key is not present in the map,
-    /// the updater will be given the result of V::default().
-    pub fn update<F, I>(&self, key: I, ctx: AddCtx<A>, f: F) -> Op<K, V, A>
+    /// Update a value under some key.
+    ///
+    /// If the key is not present in the map, the updater will be given the
+    /// result of `V::default()`. The `default` value is used to ensure
+    /// eventual consistency since our `Map`'s values are CRDTs themselves.
+    ///
+    /// The `impl Into<K>` bound provides a nice way of providing an input key that
+    /// can easily convert to the `Map`'s key. For example, we can call this function
+    /// with `"hello": &str` and it can be converted to `String`.
+    pub fn update<F>(&self, key: impl Into<K>, ctx: AddCtx<A>, f: F) -> Op<K, V, A>
     where
         F: FnOnce(&V, AddCtx<A>) -> V::Op,
-        I: Into<K>,
         V: Default,
     {
         let key = key.into();
@@ -279,6 +285,10 @@ impl<K: Ord, V: Val<A>, A: Actor> Map<K, V, A> {
     }
 
     /// Remove an entry from the Map
+    ///
+    /// The `impl Into<K>` bound provides a nice way of providing an input key that
+    /// can easily convert to the `Map`'s key. For example, we can call this function
+    /// with `"hello": &str` and it can be converted to `String`.
     pub fn rm(&self, key: impl Into<K>, ctx: RmCtx<A>) -> Op<K, V, A> {
         let mut keyset = BTreeSet::new();
         keyset.insert(key.into());

--- a/src/map.rs
+++ b/src/map.rs
@@ -284,7 +284,7 @@ impl<K: Ord, V: Val<A>, A: Actor> Map<K, V, A> {
         keyset.insert(key.into());
         Op::Rm {
             clock: ctx.clock,
-            keyset: keyset,
+            keyset,
         }
     }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -76,13 +76,13 @@ impl<V: Val<A> + Default, A: Actor> Default for Entry<V, A> {
     }
 }
 
-impl<K: Ord, V: Val<A>, A: Actor> Default for Map<K, V, A> {
+impl<K: Ord, V: Val<A> + Default, A: Actor> Default for Map<K, V, A> {
     fn default() -> Self {
         Map::new()
     }
 }
 
-impl<K: Ord, V: Val<A>, A: Actor> Causal<A> for Map<K, V, A> {
+impl<K: Ord, V: Val<A> + Default, A: Actor> Causal<A> for Map<K, V, A> {
     fn forget(&mut self, clock: &VClock<A>) {
         self.entries = mem::replace(&mut self.entries, BTreeMap::new())
             .into_iter()
@@ -137,7 +137,7 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> CmRDT for Map<K, V, A> {
     }
 }
 
-impl<K: Ord, V: Val<A>, A: Actor> CvRDT for Map<K, V, A> {
+impl<K: Ord, V: Val<A> + Default, A: Actor> CvRDT for Map<K, V, A> {
     fn merge(&mut self, other: Self) {
         self.entries = mem::replace(&mut self.entries, BTreeMap::new())
             .into_iter()
@@ -219,7 +219,7 @@ impl<K: Ord, V: Val<A>, A: Actor> CvRDT for Map<K, V, A> {
     }
 }
 
-impl<K: Ord, V: Val<A>, A: Actor> Map<K, V, A> {
+impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
     /// Constructs an empty Map
     pub fn new() -> Self {
         Self {
@@ -272,7 +272,6 @@ impl<K: Ord, V: Val<A>, A: Actor> Map<K, V, A> {
     pub fn update<F>(&self, key: impl Into<K>, ctx: AddCtx<A>, f: F) -> Op<K, V, A>
     where
         F: FnOnce(&V, AddCtx<A>) -> V::Op,
-        V: Default,
     {
         let key = key.into();
         let dot = ctx.dot.clone();

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -1,7 +1,6 @@
 /// Observed-Remove Set With Out Tombstones (ORSWOT), ported directly from `riak_dt`.
-use std::collections::{HashMap, HashSet};
 use std::cmp::Ordering;
-use std::fmt::Debug;
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::iter::{once, FromIterator};
 use std::mem;
@@ -13,8 +12,8 @@ use crate::traits::{Causal, CmRDT, CvRDT};
 use crate::vclock::{Actor, Dot, VClock};
 
 /// Trait bound alias for members in a set
-pub trait Member: Debug + Clone + Hash + Eq {}
-impl<T: Debug + Clone + Hash + Eq> Member for T {}
+pub trait Member: Clone + Hash + Eq {}
+impl<T: Clone + Hash + Eq> Member for T {}
 
 /// `Orswot` is an add-biased or-set without tombstones ported from
 /// the riak_dt CRDT library.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 use crate::vclock::{Actor, VClock};
 
 /// State based CRDT's replicate by transmitting the entire CRDT state.
@@ -31,7 +29,7 @@ pub trait CmRDT {
     /// Applying ops in any of the valid orders will converge to the same CRDT state
     ///
     /// Op's must be idempotent, meaning any Op may be applied more than once.
-    type Op: Debug;
+    type Op;
 
     /// Apply an Op to the CRDT
     fn apply(&mut self, op: Self::Op);
@@ -50,7 +48,7 @@ pub trait Causal<A: Actor> {
 /// E.g. the unicity of timestamp assumption in LWWReg
 pub trait FunkyCvRDT {
     /// User chosen error type
-    type Error: Debug;
+    type Error;
 
     /// Merge the given CRDT into the current CRDT.
     fn merge(&mut self, other: Self) -> Result<(), Self::Error>;
@@ -63,10 +61,10 @@ pub trait FunkyCvRDT {
 /// E.g. the unicity property of timestamp assumption in LWWReg
 pub trait FunkyCmRDT {
     /// User chosen error type
-    type Error: Debug;
+    type Error;
 
     /// Same Op laws from non-funky CmRDT above
-    type Op: Debug + Clone;
+    type Op;
 
     /// Apply an Op to the CRDT
     fn apply(&mut self, op: Self::Op) -> Result<(), Self::Error>;

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -15,7 +15,7 @@
 // TODO: we have a mixture of language here with witness and actor. Clean this up
 use std::cmp::{self, Ordering};
 use std::collections::{btree_map, BTreeMap};
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Display};
 use std::hash::Hash;
 use std::mem;
 
@@ -25,8 +25,8 @@ use crate::traits::{Causal, CmRDT, CvRDT};
 
 /// Common Actor type. Actors are unique identifier for every `thing` mutating a VClock.
 /// VClock based CRDT's will need to expose this Actor type to the user.
-pub trait Actor: Ord + Clone + Hash + Debug {}
-impl<A: Ord + Clone + Hash + Debug> Actor for A {}
+pub trait Actor: Ord + Clone + Hash {}
+impl<A: Ord + Clone + Hash> Actor for A {}
 
 /// Dot is a version marker for a single actor
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/test/map.rs
+++ b/test/map.rs
@@ -376,8 +376,8 @@ fn test_idempotent_quickcheck_bug1() {
             },
         },
         map::Op::Rm {
-            clock: [Dot::new(21, 5)].into_iter().cloned().collect(),
-            keyset: [0].into_iter().copied().collect(),
+            clock: [Dot::new(21, 5)].iter().cloned().collect(),
+            keyset: [0].iter().copied().collect(),
         },
         map::Op::Up {
             dot: Dot::new(21, 6),


### PR DESCRIPTION
As mentioned in #63 I wanted to propose that traits are loosened.

* I removed `Debug` and `Clone` from some of them. They ended up not being used.
* For cases that they were used, I tried to localise them on the functions that needed them.
* For cases that left only one needed trait, I replaced the old trait. For example `Ord` replaced `Key` in `src/map.rs`
* In `src/traits.rs` I removed the bounds on the associated types.
* In the case of `Actor` it made sense to keep the repeated traits :ok_hand: 

The other thing was that I updated `Map` to have two update functions. One that took a default value, the other that uses a provided default value. This seems like it would be useful for users :grin: 

Hope this works for you. Let me know if I can do anything better :bowing_man: 