### PR TITLE
Usability improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ path = "test/test.rs"
 [dependencies]
 num-bigint = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
+quickcheck = "0.6.2"
 
 [dev-dependencies]
-quickcheck = "0.6.2"
 rand = "0.4"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "test/test.rs"
 [dependencies]
 num-bigint = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
-quickcheck = "0.6.2"
+quickcheck = "0.9.2"
 
 [dev-dependencies]
 rand = "0.4"

--- a/examples/vclock.rs
+++ b/examples/vclock.rs
@@ -12,7 +12,7 @@ fn main() {
 
     // alice and bob take a copy ...
     let mut bobs_copy = shared_password.clone();
-    let mut alices_copy = shared_password.clone();
+    let mut alices_copy = shared_password;
 
     // bob edits the shared password..
     bobs_copy

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::traits::CmRDT;
-use crate::vclock::{Actor, Dot, VClock};
+use crate::{Actor, CmRDT, Dot, VClock};
 
 /// ReadCtx's are used to extract data from CRDT's while maintaining some causal history.
 /// You should store ReadCtx's close to where mutation is exposed to the user.

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,10 +1,9 @@
 use std::cmp::{Ordering, PartialOrd};
 use std::hash::{Hash, Hasher};
 
-use quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
 
-use crate::Actor;
+use crate::quickcheck::{Arbitrary, Gen};
 
 /// Dot is a version marker for a single actor
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -15,7 +14,7 @@ pub struct Dot<A> {
     pub counter: u64,
 }
 
-impl<A: Actor> Dot<A> {
+impl<A: Clone> Dot<A> {
     /// Build a Dot from an actor and counter
     pub fn new(actor: A, counter: u64) -> Self {
         Self { actor, counter }
@@ -57,12 +56,17 @@ impl<A: PartialOrd> PartialOrd for Dot<A> {
     }
 }
 
-impl<A: Arbitrary> Arbitrary for Dot<A> {
+impl<A: Arbitrary + Clone> Arbitrary for Dot<A> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         Dot {
             actor: A::arbitrary(g),
             counter: u64::arbitrary(g) % 100, // TODO: is this fair?
         }
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        let shrunk_dots = vec![Self::new(self.actor.clone(), self.counter - 1)];
+        Box::new(shrunk_dots.into_iter())
     }
 }
 

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -60,12 +60,15 @@ impl<A: Arbitrary + Clone> Arbitrary for Dot<A> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         Dot {
             actor: A::arbitrary(g),
-            counter: u64::arbitrary(g) % 100, // TODO: is this fair?
+            counter: u64::arbitrary(g) % 50,
         }
     }
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-        let shrunk_dots = vec![Self::new(self.actor.clone(), self.counter - 1)];
+        let mut shrunk_dots = Vec::new();
+        if self.counter > 0 {
+            shrunk_dots.push(Self::new(self.actor.clone(), self.counter - 1));
+        }
         Box::new(shrunk_dots.into_iter())
     }
 }

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
+
+use crate::Actor;
+
+/// Dot is a version marker for a single actor
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Dot<A> {
+    /// The actor identifier
+    pub actor: A,
+    /// The current version of this actor
+    pub counter: u64,
+}
+
+impl<A: Actor> Dot<A> {
+    /// Build a Dot from an actor and counter
+    pub fn new(actor: A, counter: u64) -> Self {
+        Self { actor, counter }
+    }
+}
+
+impl<A: Copy> Copy for Dot<A> {}
+
+impl<A: PartialEq> PartialEq for Dot<A> {
+    fn eq(&self, other: &Self) -> bool {
+        self.actor == other.actor && self.counter == other.counter
+    }
+}
+
+impl<A: Eq> Eq for Dot<A> {}
+
+impl<A: Actor + Hash> Hash for Dot<A> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.actor.hash(state);
+        self.counter.hash(state);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,7 @@ impl error::Error for Error {
             Error::ConflictingMarker => "Dot's are used exactly once for the lifetime of a CRDT",
         }
     }
+
     fn cause(&self) -> Option<&dyn error::Error> {
         match self {
             Error::ConflictingMarker => None,

--- a/src/gcounter.rs
+++ b/src/gcounter.rs
@@ -1,8 +1,7 @@
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::{Causal, CmRDT, CvRDT};
-use crate::vclock::{Actor, Dot, VClock};
+use crate::{Actor, Causal, CmRDT, CvRDT, Dot, VClock};
 
 /// `GCounter` is a grow-only witnessed counter.
 ///

--- a/src/gset.rs
+++ b/src/gset.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
-use crate::traits::{CmRDT, CvRDT};
+use crate::{CmRDT, CvRDT};
 
 /// A `GSet` is a grow-only set.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod error;
 pub use crate::error::Error;
 
 mod traits;
-pub use crate::traits::{Causal, CmRDT, CvRDT, FunkyCmRDT, FunkyCvRDT};
+pub use crate::traits::{Actor, Causal, CmRDT, CvRDT, FunkyCmRDT, FunkyCvRDT};
 
 /// This module contains a Last-Write-Wins Register.
 pub mod lwwreg;
@@ -22,7 +22,11 @@ pub mod lwwreg;
 /// This module contains a Multi-Value Register.
 pub mod mvreg;
 
+/// This module contains the Vector Clock
 pub mod vclock;
+
+/// This module contains the Dot (Actor + Sequence Number)
+pub mod dot;
 
 /// This module contains an Observed-Remove Set With Out Tombstones.
 pub mod orswot;
@@ -44,12 +48,6 @@ pub mod ctx;
 
 // Top-level re-exports for CRDT structures.
 pub use crate::{
-    gcounter::GCounter,
-    gset::GSet,
-    lwwreg::LWWReg,
-    map::Map,
-    mvreg::MVReg,
-    orswot::Orswot,
-    pncounter::PNCounter,
-    vclock::{Dot, VClock},
+    dot::Dot, gcounter::GCounter, gset::GSet, lwwreg::LWWReg, map::Map, mvreg::MVReg,
+    orswot::Orswot, pncounter::PNCounter, vclock::VClock,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,11 @@ pub mod map;
 /// This module contains context for editing a CRDT.
 pub mod ctx;
 
-// Top-level re-exports for CRDT structures.
+/// Top-level re-exports for CRDT structures.
 pub use crate::{
     dot::Dot, gcounter::GCounter, gset::GSet, lwwreg::LWWReg, map::Map, mvreg::MVReg,
     orswot::Orswot, pncounter::PNCounter, vclock::VClock,
 };
+
+/// A re-export of the quickcheck crate for use in property based testing of user code
+pub use quickcheck;

--- a/src/lwwreg.rs
+++ b/src/lwwreg.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use crate::error::{self, Error, Result};
-use crate::traits::{FunkyCmRDT, FunkyCvRDT};
+use crate::error::{Error, Result};
+use crate::{FunkyCmRDT, FunkyCvRDT};
 
 /// `LWWReg` is a simple CRDT that contains an arbitrary value
 /// along with an `Ord` that tracks causality. It is the responsibility
@@ -28,7 +28,7 @@ impl<V: Default, M: Ord + Default> Default for LWWReg<V, M> {
 }
 
 impl<V: PartialEq, M: Ord> FunkyCvRDT for LWWReg<V, M> {
-    type Error = error::Error;
+    type Error = Error;
 
     /// Combines two `LWWReg` instances according to the marker that
     /// tracks causality. Returns an error if the marker is identical but the
@@ -46,7 +46,8 @@ impl<V: PartialEq, M: Ord> FunkyCvRDT for LWWReg<V, M> {
 }
 
 impl<V: PartialEq, M: Ord> FunkyCmRDT for LWWReg<V, M> {
-    type Error = error::Error;
+    type Error = Error;
+
     // LWWReg's are small enough that we can replicate
     // the entire state as an Op
     type Op = Self;

--- a/src/map.rs
+++ b/src/map.rs
@@ -6,8 +6,7 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use crate::ctx::{AddCtx, ReadCtx, RmCtx};
-use crate::traits::{Causal, CmRDT, CvRDT};
-use crate::vclock::{Actor, Dot, VClock};
+use crate::{Actor, Causal, CmRDT, CvRDT, Dot, VClock};
 
 /// Val Trait alias to reduce redundancy in type decl.
 pub trait Val<A: Actor>: Clone + Causal<A> + CmRDT + CvRDT {}

--- a/src/mvreg.rs
+++ b/src/mvreg.rs
@@ -5,8 +5,7 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use crate::ctx::{AddCtx, ReadCtx};
-use crate::traits::{Causal, CmRDT, CvRDT};
-use crate::vclock::{Actor, VClock};
+use crate::{Actor, Causal, CmRDT, CvRDT, VClock};
 
 /// MVReg (Multi-Value Register)
 /// On concurrent writes, we will keep all values for which

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -8,6 +8,7 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use crate::ctx::{AddCtx, ReadCtx, RmCtx};
+use crate::quickcheck::{Arbitrary, Gen};
 use crate::{Actor, Causal, CmRDT, CvRDT, Dot, VClock};
 
 /// Trait bound alias for members in a set
@@ -287,6 +288,70 @@ impl<M: Member, A: Actor> Orswot<M, A> {
         for (clock, entries) in deferred.into_iter() {
             self.apply_rm(entries, clock)
         }
+    }
+}
+
+impl<A: Actor + Arbitrary, M: Member + Arbitrary> Arbitrary for Op<M, A> {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let dot = Dot::arbitrary(g);
+        let clock = VClock::arbitrary(g);
+
+        let mut members = HashSet::new();
+        for _ in 0..u8::arbitrary(g) % 10 {
+            members.insert(M::arbitrary(g));
+        }
+
+        let op = match u8::arbitrary(g) % 2 {
+            0 => Op::Add { members, dot },
+            1 => Op::Rm { members, clock },
+            _ => panic!("tried to generate invalid op"),
+        };
+
+        op
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        let mut shrunk_ops = Vec::new();
+        match self {
+            Op::Add { members, dot } => {
+                for m in members.iter() {
+                    let mut shrunk_members = members.clone();
+                    shrunk_members.remove(m);
+
+                    shrunk_ops.push(Op::Add {
+                        members: shrunk_members,
+                        dot: dot.clone(),
+                    });
+                }
+
+                dot.shrink().for_each(|shrunk_dot| {
+                    shrunk_ops.push(Op::Add {
+                        members: members.clone(),
+                        dot: shrunk_dot,
+                    })
+                });
+            }
+            Op::Rm { members, clock } => {
+                for m in members.iter() {
+                    let mut shrunk_members = members.clone();
+                    shrunk_members.remove(m);
+
+                    shrunk_ops.push(Op::Rm {
+                        members: shrunk_members,
+                        clock: clock.clone(),
+                    });
+                }
+
+                clock.shrink().for_each(|shrunk_clock| {
+                    shrunk_ops.push(Op::Rm {
+                        members: members.clone(),
+                        clock: shrunk_clock,
+                    })
+                });
+            }
+        }
+
+        Box::new(shrunk_ops.into_iter())
     }
 }
 

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -192,6 +192,11 @@ impl<M: Member, A: Actor> Orswot<M, A> {
         }
     }
 
+    /// Return a snapshot of the ORSWOT clock
+    pub fn clock(&self) -> VClock<A> {
+        self.clock.clone()
+    }
+
     /// Add a single element.
     pub fn add(&self, member: M, ctx: AddCtx<A>) -> Op<M, A> {
         Op::Add {

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -8,8 +8,7 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use crate::ctx::{AddCtx, ReadCtx, RmCtx};
-use crate::traits::{Causal, CmRDT, CvRDT};
-use crate::vclock::{Actor, Dot, VClock};
+use crate::{Actor, Causal, CmRDT, CvRDT, Dot, VClock};
 
 /// Trait bound alias for members in a set
 pub trait Member: Clone + Hash + Eq {}

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -301,13 +301,11 @@ impl<A: Actor + Arbitrary, M: Member + Arbitrary> Arbitrary for Op<M, A> {
             members.insert(M::arbitrary(g));
         }
 
-        let op = match u8::arbitrary(g) % 2 {
+        match u8::arbitrary(g) % 2 {
             0 => Op::Add { members, dot },
             1 => Op::Rm { members, clock },
             _ => panic!("tried to generate invalid op"),
-        };
-
-        op
+        }
     }
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {

--- a/src/pncounter.rs
+++ b/src/pncounter.rs
@@ -1,9 +1,8 @@
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 
-use crate::gcounter::GCounter;
 use crate::traits::{Causal, CmRDT, CvRDT};
-use crate::vclock::{Actor, Dot, VClock};
+use crate::{Actor, Dot, GCounter, VClock};
 
 /// `PNCounter` allows the counter to be both incremented and decremented
 /// by representing the increments (P) and the decrements (N) in separate

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,11 @@
-use crate::vclock::{Actor, VClock};
+use std::hash::Hash;
+
+use crate::VClock;
+
+/// Common Actor type. Actors are unique identifier for every `thing` mutating a VClock.
+/// VClock based CRDT's will need to expose this Actor type to the user.
+pub trait Actor: Ord + Clone + Hash {}
+impl<A: Ord + Clone + Hash> Actor for A {}
 
 /// State based CRDT's replicate by transmitting the entire CRDT state.
 pub trait CvRDT {

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -15,34 +15,12 @@
 use std::cmp::{self, Ordering};
 use std::collections::{btree_map, BTreeMap};
 use std::fmt::{self, Display};
-use std::hash::{Hash, Hasher};
-
+use std::hash::Hash;
 use std::mem;
 
 use serde::{Deserialize, Serialize};
 
-use crate::traits::{Causal, CmRDT, CvRDT};
-
-/// Common Actor type. Actors are unique identifier for every `thing` mutating a VClock.
-/// VClock based CRDT's will need to expose this Actor type to the user.
-pub trait Actor: Ord + Clone + Hash {}
-impl<A: Ord + Clone + Hash> Actor for A {}
-
-/// Dot is a version marker for a single actor
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Dot<A> {
-    /// The actor identifier
-    pub actor: A,
-    /// The current version of this actor
-    pub counter: u64,
-}
-
-impl<A: Actor> Dot<A> {
-    /// Build a Dot from an actor and counter
-    pub fn new(actor: A, counter: u64) -> Self {
-        Self { actor, counter }
-    }
-}
+use crate::{Actor, Causal, CmRDT, CvRDT, Dot};
 
 /// A `VClock` is a standard vector clock.
 /// It contains a set of "actors" and associated counters.
@@ -317,14 +295,5 @@ impl<A: Actor> From<Dot<A>> for VClock<A> {
         let mut clock = VClock::new();
         clock.apply(dot);
         clock
-    }
-}
-
-impl<A: Actor + Copy> Copy for Dot<A> {}
-
-impl<A: Actor + Hash> Hash for Dot<A> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.actor.hash(state);
-        self.counter.hash(state);
     }
 }

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -309,7 +309,7 @@ impl<A: Actor + Arbitrary> Arbitrary for VClock<A> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let mut clock = VClock::new();
 
-        for _ in 0..u8::arbitrary(g) {
+        for _ in 0..u8::arbitrary(g) % 10 {
             clock.apply(Dot::arbitrary(g));
         }
 

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -45,6 +45,12 @@ impl<A: Actor> Default for VClock<A> {
 
 impl<A: Actor> PartialOrd for VClock<A> {
     fn partial_cmp(&self, other: &VClock<A>) -> Option<Ordering> {
+        // This algorithm is pretty naive, I think there's a way to
+        // just track if the ordering changes as we iterate over the
+        // active dots zipped by actor.
+        // ie. it's None if the ordering changes from Less to Greator
+        //     or vice-versa.
+
         if self == other {
             Some(Ordering::Equal)
         } else if other.dots.iter().all(|(w, c)| self.get(w) >= *c) {

--- a/test/map.rs
+++ b/test/map.rs
@@ -1,8 +1,6 @@
 use crdts::{map, mvreg, Causal, CmRDT, CvRDT, Dot, MVReg, Map, VClock};
 use quickcheck::TestResult;
 
-use super::vclock;
-
 type TActor = u8;
 type TKey = u8;
 type TVal = MVReg<u8, TActor>;
@@ -794,7 +792,7 @@ quickcheck! {
     fn prop_forget_than_merge_same_as_merge_than_forget(
         ops1_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
         ops2_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        vclock_prim: Vec<u8>
+        vclock: VClock<u8>
     ) -> TestResult {
         let ops1 = build_ops(ops1_prim);
         let ops2 = build_ops(ops2_prim);
@@ -808,8 +806,6 @@ quickcheck! {
 
         apply_ops(&mut m1, &ops1.1);
         apply_ops(&mut m2, &ops2.1);
-
-        let vclock = vclock::build_vclock(vclock_prim);
 
         let mut m1_forget_after = m1.clone();
         let m2_forget_after = m2.clone();

--- a/test/map.rs
+++ b/test/map.rs
@@ -376,8 +376,8 @@ fn test_idempotent_quickcheck_bug1() {
             },
         },
         map::Op::Rm {
-            clock: [Dot::new(21, 5)].iter().cloned().collect(),
-            keyset: [0].iter().copied().collect(),
+            clock: vec![Dot::new(21, 5)].into_iter().collect(),
+            keyset: vec![0].into_iter().collect(),
         },
         map::Op::Up {
             dot: Dot::new(21, 6),

--- a/test/map.rs
+++ b/test/map.rs
@@ -129,7 +129,7 @@ fn test_remove() {
     let mut inner_map: Map<TKey, TVal, TActor> = Map::new();
     inner_map.apply(inner_map.update(110, add_ctx.clone(), |r, ctx| r.write(0, ctx)));
 
-    m.apply(m.update(101, add_ctx.clone(), |m, ctx| {
+    m.apply(m.update(101, add_ctx, |m, ctx| {
         m.update(110, ctx, |r, ctx| r.write(0, ctx))
     }));
 

--- a/test/map.rs
+++ b/test/map.rs
@@ -16,14 +16,14 @@ fn build_ops(prims: (u8, Vec<(u8, u8, u8, u8, u8)>)) -> (TActor, Vec<TOp>) {
     for (i, op_data) in ops_data.into_iter().enumerate() {
         let (choice, inner_choice, key, inner_key, val) = op_data;
         let clock: VClock<_> = Dot::new(actor, i as u64).into();
-
+        let dot = clock.inc(actor);
         let op = match choice % 2 {
             0 => map::Op::Up {
-                dot: clock.inc(actor),
+                dot,
                 key,
                 op: match inner_choice % 2 {
                     0 => map::Op::Up {
-                        dot: clock.inc(actor),
+                        dot,
                         key: inner_key,
                         op: mvreg::Op::Put { clock, val },
                     },

--- a/test/orswot.rs
+++ b/test/orswot.rs
@@ -24,7 +24,7 @@ quickcheck! {
             for op in ops.iter() {
                 let actor_opt = match op {
                     Op::Add { dot, ..} => Some(dot.actor),
-                    Op::Rm { clock, ..} => clock.iter().nth(0).map(|d| *d.actor) // any actor will do for Rm
+                    Op::Rm { clock, ..} => clock.iter().next().map(|d| *d.actor) // any actor will do for Rm
                 };
 
                 if let Some(actor) = actor_opt {

--- a/test/vclock.rs
+++ b/test/vclock.rs
@@ -2,17 +2,8 @@ use crdts::*;
 
 use std::cmp::Ordering;
 
-pub fn build_vclock(prims: Vec<u8>) -> VClock<u8> {
-    let mut v = VClock::new();
-    for actor in prims {
-        v.apply(v.inc(actor));
-    }
-    v
-}
-
 quickcheck! {
-    fn prop_into_iter_produces_same_vclock(prims: Vec<u8>) -> bool {
-        let clock = build_vclock(prims);
+    fn prop_into_iter_produces_same_vclock(clock: VClock<u8>) -> bool {
         clock == clock.clone().into_iter().collect()
     }
 
@@ -42,18 +33,14 @@ quickcheck! {
         single == double
     }
 
-    fn prop_glb_self_is_nop(prims: Vec<u8>) -> bool {
-        let clock = build_vclock(prims);
+    fn prop_glb_self_is_nop(clock: VClock<u8>) -> bool {
         let mut clock_glb = clock.clone();
         clock_glb.glb(&clock);
 
         clock_glb == clock
     }
 
-    fn prop_glb_commutes(prims_a: Vec<u8>, prims_b: Vec<u8>) -> bool {
-        let a = build_vclock(prims_a);
-        let b = build_vclock(prims_b);
-
+    fn prop_glb_commutes(a: VClock<u8>, b: VClock<u8>) -> bool {
         let mut a_glb = a.clone();
         a_glb.glb(&b);
 
@@ -63,24 +50,20 @@ quickcheck! {
         a_glb == b_glb
     }
 
-    fn prop_forget_with_empty_is_nop(prims: Vec<u8>) -> bool {
-        let clock = build_vclock(prims);
+    fn prop_forget_with_empty_is_nop(clock: VClock<u8>) -> bool {
         let mut subbed  = clock.clone();
         subbed.forget(&VClock::new());
         subbed == clock
     }
 
-    fn prop_forget_self_is_empty(prims: Vec<u8>) -> bool {
-        let clock = build_vclock(prims);
+    fn prop_forget_self_is_empty(clock: VClock<u8>) -> bool {
         let mut subbed  = clock.clone();
         subbed.forget(&clock);
         subbed == VClock::new()
     }
 
-    fn prop_forget_is_empty_implies_equal_or_greator(prims_a: Vec<u8>, prims_b: Vec<u8>) -> bool {
-        let mut a = build_vclock(prims_a);
-        let b = build_vclock(prims_b);
-
+    fn prop_forget_is_empty_implies_equal_or_greator(a: VClock<u8>, b: VClock<u8>) -> bool {
+        let mut a = a;
         a.forget(&b);
 
         if a.is_empty() {

--- a/test/vclock.rs
+++ b/test/vclock.rs
@@ -16,31 +16,27 @@ quickcheck! {
         clock == clock.clone().into_iter().collect()
     }
 
-    fn prop_dots_are_commutative_in_from_iter(dots: Vec<(u8, u64)>) -> bool {
+    fn prop_dots_are_commutative_in_from_iter(dots: Vec<Dot<u8>>) -> bool {
         // TODO: is there a better way to check comutativity of dots?
         let reverse: VClock<u8> = dots.clone()
             .into_iter()
-            .map(|(a, c)| Dot::new(a, c))
             .rev()
             .collect();
         let forward: VClock<u8> = dots
             .into_iter()
-            .map(|(a, c)| Dot::new(a, c))
             .collect();
 
         reverse == forward
     }
 
-    fn prop_idempotent_dots_in_from_iter(dots: Vec<(u8, u64)>) -> bool {
+    fn prop_idempotent_dots_in_from_iter(dots: Vec<Dot<u8>>) -> bool {
         let single: VClock<u8> = dots.clone()
             .into_iter()
-            .map(|(a, c)| Dot::new(a, c))
             .collect();
 
         let double: VClock<u8> = dots.clone()
             .into_iter()
             .chain(dots.into_iter())
-            .map(|(a, c)| Dot::new(a, c))
             .collect();
 
         single == double

--- a/test/vclock.rs
+++ b/test/vclock.rs
@@ -44,7 +44,7 @@ quickcheck! {
         let mut a_glb = a.clone();
         a_glb.glb(&b);
 
-        let mut b_glb = b.clone();
+        let mut b_glb = b;
         b_glb.glb(&a);
 
         a_glb == b_glb
@@ -152,6 +152,7 @@ fn test_merge_same_id() {
 }
 
 #[test]
+#[allow(clippy::neg_cmp_op_on_partial_ord)]
 fn test_vclock_ordering() {
     assert_eq!(VClock::<i8>::new(), VClock::new());
 


### PR DESCRIPTION
Lots of little fixes found from usage.

Property based testing:
* re-export quickcheck to avoid version conflicts
* Exporting implementations of `quickcheck::Arbitrary` for a few CRDT's, lets users property test their apps more easily

Dot:
1. Gets it's own module
2. impl PartialOrd for Dot

Actor:
1. moves to traits.rs

ORSWOT:
1. `Orswot::clock()` -> returns the global clock of the orswot
2. `impl Arbitrary for orswot::Op`

VClock:
1. `VClock::dot()` -> usually I find I want to be working at the dot level instead of the counter level
2. `impl Arbitrary for VClock`