### PR TITLE
Version Vector with Exceptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ quickcheck = "0.9"
 
 [dev-dependencies]
 quickcheck_macros = "0.9"
+derive_more = "*"
 
 [profile.release]
 debug = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@ pub mod ctx;
 /// This module contains a Sequence.
 pub mod lseq;
 
+/// Version Vector with Exceptions
+pub mod vvwe;
+
 /// Top-level re-exports for CRDT structures.
 pub use crate::{
     dot::Dot, gcounter::GCounter, gset::GSet, lwwreg::LWWReg, map::Map, mvreg::MVReg,

--- a/src/vvwe.rs
+++ b/src/vvwe.rs
@@ -1,0 +1,257 @@
+// Causality barrier
+// Keeps for each known peer, keeps track of the latest clock seen
+// And a set of messages that are from the future
+// and outputs the full-in-order sequence of messages
+//
+//
+
+#![allow(missing_docs)]
+
+use std::collections::*;
+use serde::{Deserialize, self, Serialize};
+
+/// Version Vector with Exceptions
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CausalityBarrier<A: Actor, T: CausalOp<A>> {
+    peers: HashMap<A, VectorEntry>,
+    local_id: A,
+    pub buffer: HashMap<Dot<A>, T>,
+}
+
+type LogTime = u64;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct VectorEntry {
+    // The version of the next message we'd like to see
+    max_version: LogTime,
+    exceptions: HashSet<LogTime>,
+}
+
+
+impl VectorEntry {
+    pub fn new() -> Self {
+        VectorEntry { max_version: 0, exceptions: HashSet::new() }
+    }
+
+    pub fn increment(&mut self, clk: LogTime) {
+        // We've just found an exception
+        if clk < self.max_version {
+            self.exceptions.take(&clk);
+        } else if clk == self.max_version {
+            self.max_version = self.max_version + 1;
+        } else {
+            let mut x = self.max_version + 1;
+            while x < clk {
+                self.exceptions.insert(x);
+                x = x + 1;
+            }
+        }
+    }
+
+    pub fn is_ready(&self, clk: &LogTime) -> bool {
+        *clk < self.max_version && !self.exceptions.contains(clk)
+    }
+
+    /// Calculate the difference between a remote VectorEntry and ours.
+    /// Specifically, we want the set of operations we've seen that the remote hasn't
+    pub fn diff_from(&self, other: &Self) -> HashSet<LogTime> {
+        // 1. Find (new) operations that we've seen locally that the remote hasn't
+        let local_ops = (other.max_version.into()..self.max_version.into()).into_iter().filter(|ix : &u64| {
+            !self.exceptions.contains(&(*ix).into())
+        }).map(LogTime::from);
+
+        // 2. Find exceptions that we've seen.
+        let mut local_exceptions  = other.exceptions.difference(&self.exceptions).map(|ix| ix.to_owned());
+
+        local_ops.chain(&mut local_exceptions).collect()
+    }
+}
+
+use crate::Actor;
+use crate::dot::Dot;
+
+pub trait CausalOp<A> {
+
+    /// If the result is Some(dot) then this operation cannot occur until the operation that
+    /// occured at dot has.
+    fn happens_after(&self) -> Option<Dot<A>>;
+
+    /// The time that the current operation occured at
+    fn dot(&self) -> Dot<A>;
+}
+
+impl<A: Actor, T: CausalOp<A>> CausalityBarrier<A, T> {
+    pub fn new(site_id: A) -> Self {
+        CausalityBarrier { peers: HashMap::new(), buffer: HashMap::new(), local_id: site_id }
+    }
+
+    pub fn ingest(&mut self, msg: T) -> Option<T> {
+        let v = self.peers.entry(msg.dot().actor).or_insert_with(VectorEntry::new);
+        // Have we already seen this message?
+        if v.is_ready(&msg.dot().counter) {
+            return None
+        }
+
+        v.increment(msg.dot().counter);
+
+        // Ok so it's an exception but maybe we can still integrate it if it's not constrained
+        // by a happens-before relation.
+        // For example: we can always insert into most CRDTs but we can only delete if the
+        // corresponding insert happened before!
+        match msg.happens_after() {
+            // Dang! we have a happens before relation!
+            Some(dot) => {
+                // Let's buffer this operation then.
+                if ! self.saw_site_do(&dot.actor, &dot.counter) {
+                    self.buffer.insert(dot, msg);
+                // and do nothing
+                    None
+                } else {
+                    Some(msg)
+                }
+            }
+            None => {
+                // Ok so we're not causally constrained, but maybe we already saw an associated
+                // causal operation? If so let's just delete the pair
+                match self.buffer.remove(&msg.dot()) {
+                    Some(_) => None,
+                    None => Some(msg),
+                }
+            }
+        }
+    }
+
+    fn saw_site_do(&self, site: &A, t: &LogTime) -> bool {
+        match self.peers.get(site) {
+            Some(ent) => ent.is_ready(t),
+            None => { false }
+        }
+    }
+
+    pub fn expel(&mut self, msg: T) -> T {
+        let v = self.peers.entry(msg.dot().actor).or_insert_with(VectorEntry::new);
+        v.increment(msg.dot().counter);
+        msg
+    }
+
+    pub fn diff_from(&self, other: &HashMap<A, VectorEntry>) -> HashMap<A, HashSet<LogTime>> {
+        let mut ret = HashMap::new();
+        for (site_id, entry) in self.peers.iter() {
+            let e_diff = match other.get(site_id) {
+                Some(remote_entry) => entry.diff_from(remote_entry),
+                None => (0..entry.max_version).collect(),
+            };
+            ret.insert(site_id.clone(), e_diff);
+        }
+        ret
+    }
+
+    pub fn vvwe(&self) -> HashMap<A, VectorEntry> {
+        self.peers.clone()
+    }
+
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use derive_more::{From};
+
+    #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash, PartialOrd, Ord, From, Deserialize, Serialize)]
+    pub struct SiteId(pub u32);
+
+    #[derive(PartialEq, Debug, Hash, Clone)]
+    enum Op {
+        Insert(u64),
+        Delete(SiteId, LogTime),
+    }
+
+    #[derive(PartialEq, Debug, Hash, Clone)]
+    pub struct CausalMessage {
+        time: LogTime,
+        local_id: SiteId,
+        msg: Op,
+    }
+
+    impl CausalOp<SiteId> for CausalMessage {
+        fn happens_after(&self) -> Option<Dot<SiteId>> {
+            match self.msg {
+                Op::Insert(_) => None,
+                Op::Delete(s, l) => Some(Dot::new(s, l)),
+            }
+        }
+
+        fn dot(&self) -> Dot<SiteId> {
+            Dot::new(self.local_id, self.time)
+        }
+    }
+
+    #[test]
+    fn delete_before_insert() {
+        let mut barrier = CausalityBarrier::new(0.into());
+
+        let del = CausalMessage { time: 0, local_id: 1.into(), msg: Op::Delete(1.into(), 1) };
+        let ins = CausalMessage { time: 1, local_id: 1.into(), msg: Op::Insert(0) };
+        assert_eq!(barrier.ingest(del), None);
+        assert_eq!(barrier.ingest(ins), None);
+    }
+
+    #[test]
+    fn insert() {
+        let mut barrier = CausalityBarrier::new(0.into());
+
+        let ins = CausalMessage { time: 1, local_id: 1.into(), msg: Op::Insert(0) };
+        assert_eq!(barrier.ingest(ins.clone()), Some(ins.clone()));
+    }
+
+    #[test]
+    fn insert_then_delete () {
+        let mut barrier = CausalityBarrier::new(0.into());
+
+        let ins = CausalMessage { time: 0, local_id: 1.into(), msg: Op::Insert(0) };
+        let del = CausalMessage { time: 1, local_id: 1.into(), msg: Op::Delete(1.into(), 1) };
+        assert_eq!(barrier.ingest(ins.clone()), Some(ins));
+        assert_eq!(barrier.ingest(del.clone()), Some(del));
+    }
+
+    #[test]
+    fn delete_before_insert_multiple_sites() {
+        let mut barrier = CausalityBarrier::new(0.into());
+
+        let del = CausalMessage { time: 0, local_id: 2.into(), msg: Op::Delete(1.into(), 5) };
+        let ins = CausalMessage { time: 5, local_id: 1.into(), msg: Op::Insert(0) };
+        assert_eq!(barrier.ingest(del), None);
+        assert_eq!(barrier.ingest(ins), None);
+    }
+
+    #[test]
+    fn entry_diff_new_entries() {
+        let a = VectorEntry::new();
+        let b = VectorEntry { max_version: 10, exceptions: HashSet::new() };
+
+        let c : HashSet<LogTime> = (0..10).into_iter().collect();
+        assert_eq!(b.diff_from(&a), c);
+    }
+
+
+    #[test]
+    fn entry_diff_found_exceptions() {
+        let a = VectorEntry { max_version: 10, exceptions: [1,2,3,4].iter().cloned().collect() };
+        let b = VectorEntry { max_version: 5, exceptions: HashSet::new() };
+
+        let c : HashSet<LogTime> = [1,2,3,4].iter().cloned().collect();
+        assert_eq!(b.diff_from(&a), c);
+    }
+
+    #[test]
+    fn entry_diff_complex() {
+        // a has seen 0, 5
+        let a = VectorEntry { max_version: 6, exceptions: [1,2,3,4].iter().cloned().collect() };
+        // b has seen 0, 1, 5,6,7,8
+        let b = VectorEntry { max_version: 9, exceptions:  [2, 3, 4].iter().cloned().collect() };
+
+        // c should be 1,6,7,8
+        let c : HashSet<LogTime> = [1,6,7,8].iter().cloned().collect();
+        assert_eq!(b.diff_from(&a), c);
+    }
+}

--- a/src/vvwe.rs
+++ b/src/vvwe.rs
@@ -4,74 +4,77 @@
 // and outputs the full-in-order sequence of messages
 //
 //
-
 #![allow(missing_docs)]
 
+use std::cmp::Ordering;
 use std::collections::*;
-use serde::{Deserialize, self, Serialize};
+
+use serde::{self, Deserialize, Serialize};
+
+use crate::{Actor, Dot};
 
 /// Version Vector with Exceptions
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CausalityBarrier<A: Actor, T: CausalOp<A>> {
     peers: HashMap<A, VectorEntry>,
-    local_id: A,
+    // TODO: this dot here keying the T comes from `T::happens_after()`
+    //       Why do we need to store this,
     pub buffer: HashMap<Dot<A>, T>,
 }
 
 type LogTime = u64;
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct VectorEntry {
     // The version of the next message we'd like to see
-    max_version: LogTime,
+    next_version: LogTime,
     exceptions: HashSet<LogTime>,
 }
 
-
 impl VectorEntry {
     pub fn new() -> Self {
-        VectorEntry { max_version: 0, exceptions: HashSet::new() }
+        VectorEntry::default()
     }
 
     pub fn increment(&mut self, clk: LogTime) {
-        // We've just found an exception
-        if clk < self.max_version {
-            self.exceptions.take(&clk);
-        } else if clk == self.max_version {
-            self.max_version = self.max_version + 1;
-        } else {
-            let mut x = self.max_version + 1;
-            while x < clk {
-                self.exceptions.insert(x);
-                x = x + 1;
+        match clk.cmp(&self.next_version) {
+            // We've resolved an exception
+            Ordering::Less => {
+                self.exceptions.remove(&clk);
             }
-        }
+            // This is what we expected to see as the next op
+            Ordering::Equal => self.next_version += 1,
+            // We've just found an exception
+            Ordering::Greater => (self.next_version + 1..clk).for_each(|i| {
+                self.exceptions.insert(i);
+            }),
+        };
     }
 
-    pub fn is_ready(&self, clk: &LogTime) -> bool {
-        *clk < self.max_version && !self.exceptions.contains(clk)
+    pub fn is_ready(&self, clk: LogTime) -> bool {
+        clk < self.next_version && self.no_exceptions(clk)
     }
 
     /// Calculate the difference between a remote VectorEntry and ours.
     /// Specifically, we want the set of operations we've seen that the remote hasn't
     pub fn diff_from(&self, other: &Self) -> HashSet<LogTime> {
         // 1. Find (new) operations that we've seen locally that the remote hasn't
-        let local_ops = (other.max_version.into()..self.max_version.into()).into_iter().filter(|ix : &u64| {
-            !self.exceptions.contains(&(*ix).into())
-        }).map(LogTime::from);
+        let local_ops =
+            (other.next_version..self.next_version).filter(|ix: &LogTime| self.no_exceptions(*ix));
 
         // 2. Find exceptions that we've seen.
-        let mut local_exceptions  = other.exceptions.difference(&self.exceptions).map(|ix| ix.to_owned());
+        let mut local_exceptions = other.exceptions.difference(&self.exceptions).cloned();
 
         local_ops.chain(&mut local_exceptions).collect()
     }
+
+    fn no_exceptions(&self, clk: LogTime) -> bool {
+        !self.exceptions.contains(&clk)
+    }
 }
 
-use crate::Actor;
-use crate::dot::Dot;
-
 pub trait CausalOp<A> {
-
+    /// TODO: result should be a VClock<A> since an op could be dependant on a few different msgs
     /// If the result is Some(dot) then this operation cannot occur until the operation that
     /// occured at dot has.
     fn happens_after(&self) -> Option<Dot<A>>;
@@ -81,57 +84,61 @@ pub trait CausalOp<A> {
 }
 
 impl<A: Actor, T: CausalOp<A>> CausalityBarrier<A, T> {
-    pub fn new(site_id: A) -> Self {
-        CausalityBarrier { peers: HashMap::new(), buffer: HashMap::new(), local_id: site_id }
+    pub fn new() -> Self {
+        CausalityBarrier {
+            peers: HashMap::new(),
+            buffer: HashMap::new(),
+        }
     }
 
-    pub fn ingest(&mut self, msg: T) -> Option<T> {
-        let v = self.peers.entry(msg.dot().actor).or_insert_with(VectorEntry::new);
-        // Have we already seen this message?
-        if v.is_ready(&msg.dot().counter) {
-            return None
+    pub fn ingest(&mut self, op: T) -> Option<T> {
+        let v = self.peers.entry(op.dot().actor).or_default();
+        // Have we already seen this op?
+        if v.is_ready(op.dot().counter) {
+            return None;
         }
 
-        v.increment(msg.dot().counter);
+        v.increment(op.dot().counter);
 
         // Ok so it's an exception but maybe we can still integrate it if it's not constrained
         // by a happens-before relation.
         // For example: we can always insert into most CRDTs but we can only delete if the
         // corresponding insert happened before!
-        match msg.happens_after() {
-            // Dang! we have a happens before relation!
+        match op.happens_after() {
+            // Dang! we have a happens after relation!
             Some(dot) => {
                 // Let's buffer this operation then.
-                if ! self.saw_site_do(&dot.actor, &dot.counter) {
-                    self.buffer.insert(dot, msg);
-                // and do nothing
+                if !self.saw_site_dot(&dot) {
+                    self.buffer.insert(dot, op);
+                    // and do nothing
                     None
                 } else {
-                    Some(msg)
+                    Some(op)
                 }
             }
             None => {
                 // Ok so we're not causally constrained, but maybe we already saw an associated
                 // causal operation? If so let's just delete the pair
-                match self.buffer.remove(&msg.dot()) {
-                    Some(_) => None,
-                    None => Some(msg),
+                match self.buffer.remove(&op.dot()) {
+                    Some(_) => None, // we are dropping the dependent op! that can't be right
+                    None => Some(op),
                 }
             }
         }
     }
 
-    fn saw_site_do(&self, site: &A, t: &LogTime) -> bool {
-        match self.peers.get(site) {
-            Some(ent) => ent.is_ready(t),
-            None => { false }
+    fn saw_site_dot(&self, dot: &Dot<A>) -> bool {
+	// TODO: shouldn't need to deconstruct a dot like this
+        match self.peers.get(&dot.actor) {
+            Some(ent) => ent.is_ready(dot.counter),
+            None => false,
         }
     }
 
-    pub fn expel(&mut self, msg: T) -> T {
-        let v = self.peers.entry(msg.dot().actor).or_insert_with(VectorEntry::new);
-        v.increment(msg.dot().counter);
-        msg
+    pub fn expel(&mut self, op: T) -> T {
+        let v = self.peers.entry(op.dot().actor).or_default();
+        v.increment(op.dot().counter);
+        op
     }
 
     pub fn diff_from(&self, other: &HashMap<A, VectorEntry>) -> HashMap<A, HashSet<LogTime>> {
@@ -139,7 +146,7 @@ impl<A: Actor, T: CausalOp<A>> CausalityBarrier<A, T> {
         for (site_id, entry) in self.peers.iter() {
             let e_diff = match other.get(site_id) {
                 Some(remote_entry) => entry.diff_from(remote_entry),
-                None => (0..entry.max_version).collect(),
+                None => (0..entry.next_version).collect(),
             };
             ret.insert(site_id.clone(), e_diff);
         }
@@ -149,16 +156,13 @@ impl<A: Actor, T: CausalOp<A>> CausalityBarrier<A, T> {
     pub fn vvwe(&self) -> HashMap<A, VectorEntry> {
         self.peers.clone()
     }
-
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use derive_more::{From};
 
-    #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash, PartialOrd, Ord, From, Deserialize, Serialize)]
-    pub struct SiteId(pub u32);
+    type SiteId = u32;
 
     #[derive(PartialEq, Debug, Hash, Clone)]
     enum Op {
@@ -170,12 +174,12 @@ mod test {
     pub struct CausalMessage {
         time: LogTime,
         local_id: SiteId,
-        msg: Op,
+        op: Op,
     }
 
     impl CausalOp<SiteId> for CausalMessage {
         fn happens_after(&self) -> Option<Dot<SiteId>> {
-            match self.msg {
+            match self.op {
                 Op::Insert(_) => None,
                 Op::Delete(s, l) => Some(Dot::new(s, l)),
             }
@@ -188,38 +192,66 @@ mod test {
 
     #[test]
     fn delete_before_insert() {
-        let mut barrier = CausalityBarrier::new(0.into());
+        let mut barrier = CausalityBarrier::new();
 
-        let del = CausalMessage { time: 0, local_id: 1.into(), msg: Op::Delete(1.into(), 1) };
-        let ins = CausalMessage { time: 1, local_id: 1.into(), msg: Op::Insert(0) };
+        let del = CausalMessage {
+            time: 0,
+            local_id: 1,
+            op: Op::Delete(1, 1),
+        };
+        let ins = CausalMessage {
+            time: 1,
+            local_id: 1,
+            op: Op::Insert(0),
+        };
         assert_eq!(barrier.ingest(del), None);
         assert_eq!(barrier.ingest(ins), None);
     }
 
     #[test]
     fn insert() {
-        let mut barrier = CausalityBarrier::new(0.into());
+        let mut barrier = CausalityBarrier::new();
 
-        let ins = CausalMessage { time: 1, local_id: 1.into(), msg: Op::Insert(0) };
+        let ins = CausalMessage {
+            time: 1,
+            local_id: 1,
+            op: Op::Insert(0),
+        };
         assert_eq!(barrier.ingest(ins.clone()), Some(ins.clone()));
     }
 
     #[test]
-    fn insert_then_delete () {
-        let mut barrier = CausalityBarrier::new(0.into());
+    fn insert_then_delete() {
+        let mut barrier = CausalityBarrier::new();
 
-        let ins = CausalMessage { time: 0, local_id: 1.into(), msg: Op::Insert(0) };
-        let del = CausalMessage { time: 1, local_id: 1.into(), msg: Op::Delete(1.into(), 1) };
+        let ins = CausalMessage {
+            time: 0,
+            local_id: 1,
+            op: Op::Insert(0),
+        };
+        let del = CausalMessage {
+            time: 1,
+            local_id: 1,
+            op: Op::Delete(1, 1),
+        };
         assert_eq!(barrier.ingest(ins.clone()), Some(ins));
         assert_eq!(barrier.ingest(del.clone()), Some(del));
     }
 
     #[test]
     fn delete_before_insert_multiple_sites() {
-        let mut barrier = CausalityBarrier::new(0.into());
+        let mut barrier = CausalityBarrier::new();
 
-        let del = CausalMessage { time: 0, local_id: 2.into(), msg: Op::Delete(1.into(), 5) };
-        let ins = CausalMessage { time: 5, local_id: 1.into(), msg: Op::Insert(0) };
+        let del = CausalMessage {
+            time: 0,
+            local_id: 2,
+            op: Op::Delete(1, 5),
+        };
+        let ins = CausalMessage {
+            time: 5,
+            local_id: 1,
+            op: Op::Insert(0),
+        };
         assert_eq!(barrier.ingest(del), None);
         assert_eq!(barrier.ingest(ins), None);
     }
@@ -227,31 +259,45 @@ mod test {
     #[test]
     fn entry_diff_new_entries() {
         let a = VectorEntry::new();
-        let b = VectorEntry { max_version: 10, exceptions: HashSet::new() };
+        let b = VectorEntry {
+            next_version: 10,
+            exceptions: HashSet::new(),
+        };
 
-        let c : HashSet<LogTime> = (0..10).into_iter().collect();
+        let c: HashSet<LogTime> = (0..10).into_iter().collect();
         assert_eq!(b.diff_from(&a), c);
     }
 
-
     #[test]
     fn entry_diff_found_exceptions() {
-        let a = VectorEntry { max_version: 10, exceptions: [1,2,3,4].iter().cloned().collect() };
-        let b = VectorEntry { max_version: 5, exceptions: HashSet::new() };
+        let a = VectorEntry {
+            next_version: 10,
+            exceptions: [1, 2, 3, 4].iter().cloned().collect(),
+        };
+        let b = VectorEntry {
+            next_version: 5,
+            exceptions: HashSet::new(),
+        };
 
-        let c : HashSet<LogTime> = [1,2,3,4].iter().cloned().collect();
+        let c: HashSet<LogTime> = [1, 2, 3, 4].iter().cloned().collect();
         assert_eq!(b.diff_from(&a), c);
     }
 
     #[test]
     fn entry_diff_complex() {
         // a has seen 0, 5
-        let a = VectorEntry { max_version: 6, exceptions: [1,2,3,4].iter().cloned().collect() };
+        let a = VectorEntry {
+            next_version: 6,
+            exceptions: [1, 2, 3, 4].iter().cloned().collect(),
+        };
         // b has seen 0, 1, 5,6,7,8
-        let b = VectorEntry { max_version: 9, exceptions:  [2, 3, 4].iter().cloned().collect() };
+        let b = VectorEntry {
+            next_version: 9,
+            exceptions: [2, 3, 4].iter().cloned().collect(),
+        };
 
         // c should be 1,6,7,8
-        let c : HashSet<LogTime> = [1,6,7,8].iter().cloned().collect();
+        let c: HashSet<LogTime> = [1, 6, 7, 8].iter().cloned().collect();
         assert_eq!(b.diff_from(&a), c);
     }
 }

--- a/src/vvwe.rs
+++ b/src/vvwe.rs
@@ -194,16 +194,38 @@ mod test {
     fn delete_before_insert() {
         let mut barrier = CausalityBarrier::new();
 
-        let del = CausalMessage {
-            time: 0,
-            local_id: 1,
-            op: Op::Delete(1, 1),
-        };
         let ins = CausalMessage {
-            time: 1,
+            time: 0,
             local_id: 1,
             op: Op::Insert(0),
         };
+
+        let del = CausalMessage {
+            time: 1,
+            local_id: 1,
+            op: Op::Delete(1, 0),
+        };
+
+        assert_eq!(barrier.ingest(ins.clone()), Some(ins));
+        assert_eq!(barrier.ingest(del.clone()), Some(del));
+    }
+
+    #[test]
+    fn out_of_order() {
+        let mut barrier = CausalityBarrier::new();
+
+        let ins = CausalMessage {
+            time: 0,
+            local_id: 1,
+            op: Op::Insert(0),
+        };
+
+        let del = CausalMessage {
+            time: 1,
+            local_id: 1,
+            op: Op::Delete(1, 0),
+        };
+
         assert_eq!(barrier.ingest(del), None);
         assert_eq!(barrier.ingest(ins), None);
     }


### PR DESCRIPTION
Here is an implementation of a causality buffer based on the algorithm presented in 

D. Malkhi and D. Terry, “Concise Version Vectors in WinFS,” p. 13.

The idea is to ensure we re-order messages so that they respect a causal order, which is important for datastructures like `LSEQ` where we need to receive each peer's messages in order but don't want to pay the cost of sending a full vector clock with each operation. 

The Causality Barrier is composed of two components: a version vector (with exceptions) and an unapplied operations buffer.

The Version Vector with Exceptions works by tracking two pieces of information for every known peer: the maximum message timestamp and a list of exceptions. The list of exceptions is composed of the timestamps less than the maximum which we haven't seen yet. 

When we receive a new operation we follow the following algorithm in pseudo-pseudo-code:

0. Update the version vector with A's timestamp, if  A > max then we set max = A and we add the range [old max, A) to the exceptions. Otherwise if A is in the exception set, we remove it's timestamp.  
1. Check if the operation A must occur after another operation B
2. Check if we've seen B
  a. If yes, then allow A, and check the unapplied buffer for opeations that transitively depend on A
  b. If no, buffer A
