### PR TITLE
Implement .keys, .values, .iter for Map

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -345,7 +345,43 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
         }
     }
 
-    fn keys(&self) -> impl IntoIterator<Item = ReadCtx<&K, A>> {
+    /// Gets an iterator over the keys of the `Map`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use crdts::Map;
+    /// use crdts::MVReg;
+    /// use crdts::CmRDT;
+    ///
+    /// type Actor = &'static str;
+    /// type Key = &'static str;
+    ///
+    /// let actor = "actor";
+    ///
+    /// let mut map: Map<i32, MVReg<Key, Actor>, Actor> = Map::new();
+    ///
+    /// let add_ctx = map.read_ctx().derive_add_ctx(actor);
+    /// map.apply(map.update(100, add_ctx, |v, a| v.write("foo", a)));
+    ///
+    /// let add_ctx = map.read_ctx().derive_add_ctx(actor);
+    /// map.apply(map.update(50, add_ctx, |v, a| v.write("bar", a)));
+    ///
+    /// let add_ctx = map.read_ctx().derive_add_ctx(actor);
+    /// map.apply(map.update(200, add_ctx, |v, a| v.write("baz", a)));
+    ///
+    ///
+    /// let mut items = Vec::new();
+    ///
+    /// for read_ctx in map.keys() {
+    ///     items.push(*read_ctx.val);
+    /// }
+    ///
+    /// items.sort();
+    ///
+    /// assert_eq!(items, &[50, 100, 200]);
+    /// ```
+    pub fn keys(&self) -> impl IntoIterator<Item = ReadCtx<&K, A>> {
         self.entries.keys().map(move |k| ReadCtx {
             add_clock: self.clock.clone(),
             rm_clock: self.clock.clone(),
@@ -353,7 +389,43 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
         })
     }
 
-    fn values(&self) -> impl IntoIterator<Item = ReadCtx<&V, A>> {
+    /// Gets an iterator over the values of the `Map`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use crdts::Map;
+    /// use crdts::MVReg;
+    /// use crdts::CmRDT;
+    ///
+    /// type Actor = &'static str;
+    /// type Key = &'static str;
+    ///
+    /// let actor = "actor";
+    ///
+    /// let mut map: Map<i32, MVReg<Key, Actor>, Actor> = Map::new();
+    ///
+    /// let add_ctx = map.read_ctx().derive_add_ctx(actor);
+    /// map.apply(map.update(100, add_ctx, |v, a| v.write("foo", a)));
+    ///
+    /// let add_ctx = map.read_ctx().derive_add_ctx(actor);
+    /// map.apply(map.update(50, add_ctx, |v, a| v.write("bar", a)));
+    ///
+    /// let add_ctx = map.read_ctx().derive_add_ctx(actor);
+    /// map.apply(map.update(200, add_ctx, |v, a| v.write("baz", a)));
+    ///
+    ///
+    /// let mut items = Vec::new();
+    ///
+    /// for read_ctx in map.values() {
+    ///     items.push(read_ctx.val.read().val[0]);
+    /// }
+    ///
+    /// items.sort();
+    ///
+    /// assert_eq!(items, &["bar", "baz", "foo"]);
+    /// ```
+    pub fn values(&self) -> impl IntoIterator<Item = ReadCtx<&V, A>> {
         self.entries.values().map(move |v| ReadCtx {
             add_clock: self.clock.clone(),
             rm_clock: self.clock.clone(),
@@ -361,7 +433,44 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
         })
     }
 
-    fn iter(&self) -> impl IntoIterator<Item = ReadCtx<(&K, &V), A>> {
+    /// Gets an iterator over the entries of the `Map`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use crdts::Map;
+    /// use crdts::MVReg;
+    /// use crdts::CmRDT;
+    ///
+    /// type Actor = &'static str;
+    /// type Key = &'static str;
+    ///
+    /// let actor = "actor";
+    ///
+    /// let mut map: Map<i32, MVReg<Key, Actor>, Actor> = Map::new();
+    ///
+    /// let add_ctx = map.read_ctx().derive_add_ctx(actor);
+    /// map.apply(map.update(100, add_ctx, |v, a| v.write("foo", a)));
+    ///
+    /// let add_ctx = map.read_ctx().derive_add_ctx(actor);
+    /// map.apply(map.update(50, add_ctx, |v, a| v.write("bar", a)));
+    ///
+    /// let add_ctx = map.read_ctx().derive_add_ctx(actor);
+    /// map.apply(map.update(200, add_ctx, |v, a| v.write("baz", a)));
+    ///
+    ///
+    /// let mut items = Vec::new();
+    ///
+    /// for read_ctx in map.iter() {
+    ///     let (key, value) = read_ctx.val;
+    ///     items.push((*key, value.read().val[0]));
+    /// }
+    ///
+    /// items.sort();
+    ///
+    /// assert_eq!(items, &[(50, "bar"), (100, "foo"), (200, "baz")]);
+    /// ```
+    pub fn iter(&self) -> impl IntoIterator<Item = ReadCtx<(&K, &V), A>> {
         self.entries.iter().map(move |(k, v)| ReadCtx {
             add_clock: self.clock.clone(),
             rm_clock: self.clock.clone(),

--- a/src/map.rs
+++ b/src/map.rs
@@ -344,6 +344,30 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
             _ => { /* we've seen all keys this clock has seen */ }
         }
     }
+
+    fn keys(&self) -> impl IntoIterator<Item = ReadCtx<&K, A>> {
+        self.entries.keys().map(move |k| ReadCtx {
+            add_clock: self.clock.clone(),
+            rm_clock: self.clock.clone(),
+            val: k,
+        })
+    }
+
+    fn values(&self) -> impl IntoIterator<Item = ReadCtx<&V, A>> {
+        self.entries.values().map(move |v| ReadCtx {
+            add_clock: self.clock.clone(),
+            rm_clock: self.clock.clone(),
+            val: &v.val,
+        })
+    }
+
+    fn iter(&self) -> impl IntoIterator<Item = ReadCtx<(&K, &V), A>> {
+        self.entries.iter().map(move |(k, v)| ReadCtx {
+            add_clock: self.clock.clone(),
+            rm_clock: self.clock.clone(),
+            val: (k, &v.val),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/map.rs
+++ b/src/map.rs
@@ -371,17 +371,13 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
     /// map.apply(map.update(200, add_ctx, |v, a| v.write("baz", a)));
     ///
     ///
-    /// let mut items = Vec::new();
+    /// let mut keys: Vec<_> = map.keys().map(|key_ctx| *key_ctx.val).collect();
     ///
-    /// for read_ctx in map.keys() {
-    ///     items.push(*read_ctx.val);
-    /// }
+    /// keys.sort();
     ///
-    /// items.sort();
-    ///
-    /// assert_eq!(items, &[50, 100, 200]);
+    /// assert_eq!(keys, &[50, 100, 200]);
     /// ```
-    pub fn keys(&self) -> impl IntoIterator<Item = ReadCtx<&K, A>> {
+    pub fn keys(&self) -> impl Iterator<Item = ReadCtx<&K, A>> {
         self.entries.iter().map(move |(k, v)| ReadCtx {
             add_clock: self.clock.clone(),
             rm_clock: v.clock.clone(),
@@ -415,17 +411,16 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
     /// map.apply(map.update(200, add_ctx, |v, a| v.write("baz", a)));
     ///
     ///
-    /// let mut items = Vec::new();
+    /// let mut values: Vec<_> = map
+    ///     .values()
+    ///     .map(|val_ctx| val_ctx.val.read().val[0])
+    ///     .collect();
     ///
-    /// for read_ctx in map.values() {
-    ///     items.push(read_ctx.val.read().val[0]);
-    /// }
+    /// values.sort();
     ///
-    /// items.sort();
-    ///
-    /// assert_eq!(items, &["bar", "baz", "foo"]);
+    /// assert_eq!(values, &["bar", "baz", "foo"]);
     /// ```
-    pub fn values(&self) -> impl IntoIterator<Item = ReadCtx<&V, A>> {
+    pub fn values(&self) -> impl Iterator<Item = ReadCtx<&V, A>> {
         self.entries.values().map(move |v| ReadCtx {
             add_clock: self.clock.clone(),
             rm_clock: v.clock.clone(),
@@ -459,18 +454,16 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
     /// map.apply(map.update(200, add_ctx, |v, a| v.write("baz", a)));
     ///
     ///
-    /// let mut items = Vec::new();
-    ///
-    /// for read_ctx in map.iter() {
-    ///     let (key, value) = read_ctx.val;
-    ///     items.push((*key, value.read().val[0]));
-    /// }
+    /// let mut items: Vec<_> = map
+    ///     .iter()
+    ///     .map(|item_ctx| (*item_ctx.val.0, item_ctx.val.1.read().val[0]))
+    ///     .collect();
     ///
     /// items.sort();
     ///
     /// assert_eq!(items, &[(50, "bar"), (100, "foo"), (200, "baz")]);
     /// ```
-    pub fn iter(&self) -> impl IntoIterator<Item = ReadCtx<(&K, &V), A>> {
+    pub fn iter(&self) -> impl Iterator<Item = ReadCtx<(&K, &V), A>> {
         self.entries.iter().map(move |(k, v)| ReadCtx {
             add_clock: self.clock.clone(),
             rm_clock: v.clock.clone(),

--- a/src/map.rs
+++ b/src/map.rs
@@ -382,9 +382,9 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
     /// assert_eq!(items, &[50, 100, 200]);
     /// ```
     pub fn keys(&self) -> impl IntoIterator<Item = ReadCtx<&K, A>> {
-        self.entries.keys().map(move |k| ReadCtx {
+        self.entries.iter().map(move |(k, v)| ReadCtx {
             add_clock: self.clock.clone(),
-            rm_clock: self.clock.clone(),
+            rm_clock: v.clock.clone(),
             val: k,
         })
     }
@@ -428,7 +428,7 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
     pub fn values(&self) -> impl IntoIterator<Item = ReadCtx<&V, A>> {
         self.entries.values().map(move |v| ReadCtx {
             add_clock: self.clock.clone(),
-            rm_clock: self.clock.clone(),
+            rm_clock: v.clock.clone(),
             val: &v.val,
         })
     }
@@ -473,7 +473,7 @@ impl<K: Ord, V: Val<A> + Default, A: Actor> Map<K, V, A> {
     pub fn iter(&self) -> impl IntoIterator<Item = ReadCtx<(&K, &V), A>> {
         self.entries.iter().map(move |(k, v)| ReadCtx {
             add_clock: self.clock.clone(),
-            rm_clock: self.clock.clone(),
+            rm_clock: v.clock.clone(),
             val: (k, &v.val),
         })
     }


### PR DESCRIPTION
One thing I'm not sure of is if we should be guaranteeing that the iterators return items in order of the key, like the backing BTree does. I'm playing it safe by sorting the items before the comparison and not saying we return in order of the key.

I don't have any use for that property, though.