### PR TITLE
Concise debug logs for Dot and Orswot

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::quickcheck::{Arbitrary, Gen};
 
 /// Dot is a version marker for a single actor
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Dot<A> {
     /// The actor identifier
     pub actor: A,
@@ -58,6 +58,12 @@ impl<A: PartialOrd> PartialOrd for Dot<A> {
         } else {
             None
         }
+    }
+}
+
+impl<A: std::fmt::Debug> std::fmt::Debug for Dot<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}.{:?}", self.actor, self.counter)
     }
 }
 

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -27,8 +27,8 @@ pub struct Orswot<M: Member, A: Actor> {
 /// they were produced to guarantee convergence.
 ///
 /// Op's are idempotent, that is, applying an Op twice will not have an effect
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Op<M: Member, A: Actor> {
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Op<M, A: Actor> {
     /// Add members to the set
     Add {
         /// witnessing dot
@@ -348,6 +348,15 @@ impl<A: Actor + Arbitrary, M: Member + Arbitrary> Arbitrary for Op<M, A> {
         }
 
         Box::new(shrunk_ops.into_iter())
+    }
+}
+
+impl<M: std::fmt::Debug, A: Actor + std::fmt::Debug> std::fmt::Debug for Op<M, A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Op::Add { dot, members } => write!(f, "Add({:?}, {:?})", dot, members),
+            Op::Rm { clock, members } => write!(f, "Rm({:?}, {:?})", clock, members),
+        }
     }
 }
 


### PR DESCRIPTION
`Dot { actor: "A", counter: 32 }` is now simply `A.32`

Similar but less drastic reductions for Orswot as well