### PR TITLE
Rename Causal trait to ResetRemove and remove error type from funky crdt

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::{error, fmt, result};
 
 /// CRDT Result alias to reduce redundency in function return types
-pub(crate) type Result<T> = result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
 
 /// Possible CRDT error codes
 #[derive(Debug, PartialEq)]

--- a/src/gcounter.rs
+++ b/src/gcounter.rs
@@ -1,7 +1,7 @@
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
-use crate::{Actor, Causal, CmRDT, CvRDT, Dot, VClock};
+use crate::{Actor, CmRDT, CvRDT, Dot, ResetRemove, VClock};
 
 /// `GCounter` is a grow-only witnessed counter.
 ///
@@ -46,9 +46,9 @@ impl<A: Actor> CvRDT for GCounter<A> {
     }
 }
 
-impl<A: Actor> Causal<A> for GCounter<A> {
-    fn forget(&mut self, clock: &VClock<A>) {
-        self.inner.forget(&clock);
+impl<A: Actor> ResetRemove<A> for GCounter<A> {
+    fn reset_remove(&mut self, clock: &VClock<A>) {
+        self.inner.reset_remove(&clock);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 #![deny(missing_docs)]
 
 mod error;
-pub use crate::error::Error;
+pub use crate::error::{Error, Result};
 
 mod traits;
 pub use crate::traits::{Actor, Causal, CmRDT, CvRDT, FunkyCmRDT, FunkyCvRDT};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod error;
 pub use crate::error::{Error, Result};
 
 mod traits;
-pub use crate::traits::{Actor, Causal, CmRDT, CvRDT, FunkyCmRDT, FunkyCvRDT};
+pub use crate::traits::{Actor, CmRDT, CvRDT, FunkyCmRDT, FunkyCvRDT, ResetRemove};
 
 /// This module contains a Last-Write-Wins Register.
 pub mod lwwreg;

--- a/src/lwwreg.rs
+++ b/src/lwwreg.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::error::{Error, Result};
-use crate::{FunkyCmRDT, FunkyCvRDT};
+use crate::{Error, FunkyCmRDT, FunkyCvRDT, Result};
 
 /// `LWWReg` is a simple CRDT that contains an arbitrary value
 /// along with an `Ord` that tracks causality. It is the responsibility
@@ -28,8 +27,6 @@ impl<V: Default, M: Ord + Default> Default for LWWReg<V, M> {
 }
 
 impl<V: PartialEq, M: Ord> FunkyCvRDT for LWWReg<V, M> {
-    type Error = Error;
-
     /// Combines two `LWWReg` instances according to the marker that
     /// tracks causality. Returns an error if the marker is identical but the
     /// contained element is different.
@@ -46,8 +43,6 @@ impl<V: PartialEq, M: Ord> FunkyCvRDT for LWWReg<V, M> {
 }
 
 impl<V: PartialEq, M: Ord> FunkyCmRDT for LWWReg<V, M> {
-    type Error = Error;
-
     // LWWReg's are small enough that we can replicate
     // the entire state as an Op
     type Op = Self;

--- a/src/mvreg.rs
+++ b/src/mvreg.rs
@@ -5,7 +5,7 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use crate::ctx::{AddCtx, ReadCtx};
-use crate::{Actor, Causal, CmRDT, CvRDT, VClock};
+use crate::{Actor, CmRDT, CvRDT, ResetRemove, VClock};
 
 /// MVReg (Multi-Value Register)
 /// On concurrent writes, we will keep all values for which
@@ -84,14 +84,14 @@ impl<V: PartialEq, A: Actor> PartialEq for MVReg<V, A> {
 
 impl<V: Eq, A: Actor> Eq for MVReg<V, A> {}
 
-impl<V: Clone, A: Actor> Causal<A> for MVReg<V, A> {
-    fn forget(&mut self, clock: &VClock<A>) {
+impl<V: Clone, A: Actor> ResetRemove<A> for MVReg<V, A> {
+    fn reset_remove(&mut self, clock: &VClock<A>) {
         self.vals = self
             .vals
             .clone()
             .into_iter()
             .filter_map(|(mut val_clock, val)| {
-                val_clock.forget(&clock);
+                val_clock.reset_remove(&clock);
                 if val_clock.is_empty() {
                     None // remove this value from the register
                 } else {

--- a/src/pncounter.rs
+++ b/src/pncounter.rs
@@ -1,7 +1,7 @@
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::{Causal, CmRDT, CvRDT};
+use crate::traits::{CmRDT, CvRDT, ResetRemove};
 use crate::{Actor, Dot, GCounter, VClock};
 
 /// `PNCounter` allows the counter to be both incremented and decremented
@@ -73,10 +73,10 @@ impl<A: Actor> CvRDT for PNCounter<A> {
     }
 }
 
-impl<A: Actor> Causal<A> for PNCounter<A> {
-    fn forget(&mut self, clock: &VClock<A>) {
-        self.p.forget(&clock);
-        self.n.forget(&clock);
+impl<A: Actor> ResetRemove<A> for PNCounter<A> {
+    fn reset_remove(&mut self, clock: &VClock<A>) {
+        self.p.reset_remove(&clock);
+        self.n.reset_remove(&clock);
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -54,11 +54,8 @@ pub trait Causal<A: Actor> {
 /// typesystem so we rely on runtime error checking.
 /// E.g. the unicity of timestamp assumption in LWWReg
 pub trait FunkyCvRDT {
-    /// User chosen error type
-    type Error;
-
     /// Merge the given CRDT into the current CRDT.
-    fn merge(&mut self, other: Self) -> Result<(), Self::Error>;
+    fn merge(&mut self, other: Self) -> crate::Result<()>;
 }
 
 /// Funky variant of the `CmRDT` trait.
@@ -67,12 +64,9 @@ pub trait FunkyCvRDT {
 /// typesystem so we rely on runtime error checking.
 /// E.g. the unicity property of timestamp assumption in LWWReg
 pub trait FunkyCmRDT {
-    /// User chosen error type
-    type Error;
-
     /// Same Op laws from non-funky CmRDT above
     type Op;
 
     /// Apply an Op to the CRDT
-    fn apply(&mut self, op: Self::Op) -> Result<(), Self::Error>;
+    fn apply(&mut self, op: Self::Op) -> crate::Result<()>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -43,9 +43,9 @@ pub trait CmRDT {
 }
 
 /// CRDT's are causal if they are built on top of vector clocks.
-pub trait Causal<A: Actor> {
-    /// Forget data that is strictly smaller than this clock
-    fn forget(&mut self, clock: &VClock<A>);
+pub trait ResetRemove<A: Actor> {
+    /// Remove data that is strictly smaller than this clock
+    fn reset_remove(&mut self, clock: &VClock<A>);
 }
 
 /// Funky variant of the `CvRDT` trait.

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -21,7 +21,7 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use crate::quickcheck::{Arbitrary, Gen};
-use crate::{Actor, Causal, CmRDT, CvRDT, Dot};
+use crate::{Actor, CmRDT, CvRDT, Dot, ResetRemove};
 
 /// A `VClock` is a standard vector clock.
 /// It contains a set of "actors" and associated counters.
@@ -77,10 +77,10 @@ impl<A: Actor + Display> Display for VClock<A> {
     }
 }
 
-impl<A: Actor> Causal<A> for VClock<A> {
+impl<A: Actor> ResetRemove<A> for VClock<A> {
     /// Forget any actors that have smaller counts than the
     /// count in the given vclock
-    fn forget(&mut self, other: &Self) {
+    fn reset_remove(&mut self, other: &Self) {
         for Dot { actor, counter } in other.iter() {
             if counter >= self.get(&actor) {
                 self.dots.remove(&actor);
@@ -132,7 +132,7 @@ impl<A: Actor> VClock<A> {
     /// forgotten
     pub fn clone_without(&self, base_clock: &Self) -> Self {
         let mut cloned = self.clone();
-        cloned.forget(&base_clock);
+        cloned.reset_remove(&base_clock);
         cloned
     }
 

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -216,7 +216,7 @@ impl<A: Actor> VClock<A> {
     /// Reduces this VClock to the greatest-lower-bound of the given
     /// VClock and itsef, as an example see the following code.
     /// ``` rust
-    /// use crdts::{VClock, Dot, Causal, CmRDT};
+    /// use crdts::{VClock, Dot, ResetRemove, CmRDT};
     /// let mut c = VClock::new();
     /// c.apply(Dot::new(23, 6));
     /// c.apply(Dot::new(89, 14));

--- a/test/map.rs
+++ b/test/map.rs
@@ -1,4 +1,4 @@
-use crdts::{map, mvreg, Causal, CmRDT, CvRDT, Dot, MVReg, Map, VClock};
+use crdts::{map, mvreg, CmRDT, CvRDT, Dot, MVReg, Map, ResetRemove, VClock};
 use quickcheck::TestResult;
 
 type TActor = u8;
@@ -761,7 +761,7 @@ quickcheck! {
         m == m_snapshot
     }
 
-    fn prop_forget_with_empty_vclock_is_nop(
+    fn prop_reset_remove_with_empty_vclock_is_nop(
         ops_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
     ) -> bool {
         let ops = build_ops(ops_prim);
@@ -770,18 +770,18 @@ quickcheck! {
         apply_ops(&mut m, &ops.1);
 
         let m_snapshot = m.clone();
-        m.forget(&VClock::new());
+        m.reset_remove(&VClock::new());
 
         m == m_snapshot
     }
 
-    fn prop_forget_with_map_clock_is_empty_map(
+    fn prop_reset_remove_with_map_clock_is_empty_map(
         ops_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
     ) -> bool {
         let mut m = TMap::new();
         apply_ops(&mut m, &build_ops(ops_prim).1);
 
-        m.forget(&m.len().rm_clock);
+        m.reset_remove(&m.len().rm_clock);
 
         // Map may still have some deferred removes
         // stored, so it's not neccessarily true that
@@ -789,7 +789,7 @@ quickcheck! {
         m.len().val == 0
     }
 
-    fn prop_forget_than_merge_same_as_merge_than_forget(
+    fn prop_reset_remove_than_merge_same_as_merge_than_reset_remove(
         ops1_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
         ops2_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
         vclock: VClock<u8>
@@ -807,17 +807,17 @@ quickcheck! {
         apply_ops(&mut m1, &ops1.1);
         apply_ops(&mut m2, &ops2.1);
 
-        let mut m1_forget_after = m1.clone();
-        let m2_forget_after = m2.clone();
+        let mut m1_reset_remove_after = m1.clone();
+        let m2_reset_remove_after = m2.clone();
 
-        m1.forget(&vclock);
-        m2.forget(&vclock);
+        m1.reset_remove(&vclock);
+        m2.reset_remove(&vclock);
 
         m1.merge(m2);
 
-        m1_forget_after.merge(m2_forget_after);
-        m1_forget_after.forget(&vclock);
+        m1_reset_remove_after.merge(m2_reset_remove_after);
+        m1_reset_remove_after.reset_remove(&vclock);
 
-        TestResult::from_bool(m1_forget_after == m1)
+        TestResult::from_bool(m1_reset_remove_after == m1)
     }
 }

--- a/test/mvreg.rs
+++ b/test/mvreg.rs
@@ -208,18 +208,18 @@ quickcheck! {
         TestResult::from_bool(true)
     }
 
-    fn prop_forget(r_ops: Vec<(u8, u8)>) -> bool {
+    fn prop_reset_remove(r_ops: Vec<(u8, u8)>) -> bool {
         let mut r = build_test_reg(r_ops).reg;
         let r_snapshot = r.clone();
 
         // truncating with the empty clock should be a nop
-        r.forget(&VClock::new());
+        r.reset_remove(&VClock::new());
         assert_eq!(r, r_snapshot);
 
         // truncating with the merge of all val clocks should give us
         // an empty register
         let clock = r.read().add_clock;
-        r.forget(&clock);
+        r.reset_remove(&clock);
         assert_eq!(r, MVReg::new());
         true
     }

--- a/test/vclock.rs
+++ b/test/vclock.rs
@@ -50,21 +50,21 @@ quickcheck! {
         a_glb == b_glb
     }
 
-    fn prop_forget_with_empty_is_nop(clock: VClock<u8>) -> bool {
+    fn prop_reset_remove_with_empty_is_nop(clock: VClock<u8>) -> bool {
         let mut subbed  = clock.clone();
-        subbed.forget(&VClock::new());
+        subbed.reset_remove(&VClock::new());
         subbed == clock
     }
 
-    fn prop_forget_self_is_empty(clock: VClock<u8>) -> bool {
+    fn prop_reset_remove_self_is_empty(clock: VClock<u8>) -> bool {
         let mut subbed  = clock.clone();
-        subbed.forget(&clock);
+        subbed.reset_remove(&clock);
         subbed == VClock::new()
     }
 
-    fn prop_forget_is_empty_implies_equal_or_greator(a: VClock<u8>, b: VClock<u8>) -> bool {
+    fn prop_reset_remove_is_empty_implies_equal_or_greator(a: VClock<u8>, b: VClock<u8>) -> bool {
         let mut a = a;
-        a.forget(&b);
+        a.reset_remove(&b);
 
         if a.is_empty() {
             match a.partial_cmp(&b) {
@@ -81,7 +81,7 @@ quickcheck! {
 }
 
 #[test]
-fn test_forget() {
+fn test_reset_remove() {
     let mut a: VClock<u8> = vec![Dot::new(1, 4), Dot::new(2, 3), Dot::new(5, 9)]
         .into_iter()
         .collect();
@@ -90,7 +90,7 @@ fn test_forget() {
         .collect();
     let expected: VClock<u8> = vec![Dot::new(5, 9)].into_iter().collect();
 
-    a.forget(&b);
+    a.reset_remove(&b);
     assert_eq!(a, expected);
 }
 


### PR DESCRIPTION
Causal was always a bad name for this trait, reset-remove is the name given to the behavior in the Map CRDT by the riak folks, so lets just use that.

Also the user customizable Error type in FunkyCRDT hasn't seen any usage so removing as well.