### PR TITLE
Chain CRDT - Append only data structure

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,0 +1,172 @@
+use core::cmp::Ordering;
+use core::fmt::{Debug, Display};
+use std::collections::BTreeMap;
+use std::error::Error;
+
+use crate::{
+    ctx::{AddCtx, ReadCtx},
+    CmRDT, CvRDT, VClock,
+};
+
+struct Op<V, A: Ord> {
+    value: V,
+    ctx: VClock<A>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+struct Context<A: Ord>(VClock<A>);
+
+impl<A: Ord + Clone> Ord for Context<A> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.0.partial_cmp(&other.0) {
+            Some(ordering) => ordering,
+            None => {
+                let self_without_other = self.0.clone_without(&other.0);
+                let other_without_self = other.0.clone_without(&self.0);
+                self_without_other.dots.cmp(&other_without_self.dots)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Chain<V, A: Ord + Clone> {
+    clock: VClock<A>,
+    chain: BTreeMap<Context<A>, V>,
+}
+
+#[derive(Debug)]
+enum Validation<V: Debug, A: Debug + Ord> {
+    ReusedContext {
+        ctx: VClock<A>,
+        existing_value: V,
+        op_value: V,
+    },
+}
+impl<V: Debug, A: Debug + Ord> Display for Validation<V, A> {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Debug::fmt(&self, fmt)
+    }
+}
+
+impl<V: Debug, A: Debug + Ord> Error for Validation<V, A> {}
+
+impl<V: Debug + Clone + Eq, A: Debug + Ord + Clone> CmRDT for Chain<V, A> {
+    type Op = Op<V, A>;
+    /// The validation error returned by `validate_op`.
+    type Validation = Validation<V, A>;
+
+    fn validate_op(&self, op: &Self::Op) -> Result<(), Self::Validation> {
+        match self.chain.get(&Context(op.ctx.clone())) {
+            Some(existing_value) => {
+                if existing_value != &op.value {
+                    return Err(Validation::ReusedContext {
+                        ctx: op.ctx.clone(),
+                        existing_value: existing_value.clone(),
+                        op_value: op.value.clone(),
+                    });
+                }
+            }
+            None => (),
+        }
+
+        Ok(())
+    }
+
+    /// Apply an Op to the CRDT
+    fn apply(&mut self, op: Self::Op) {
+        let Op { ctx, value } = op;
+        if self.clock >= ctx {
+            // We've already seen this operation, dropping
+        } else {
+            self.clock.merge(ctx.clone());
+            self.chain.insert(Context(ctx), value);
+        }
+    }
+}
+
+impl<V: Eq, A: Ord + Clone> Chain<V, A> {
+    fn append(&self, v: impl Into<V>, ctx: AddCtx<A>) -> Op<V, A> {
+        Op {
+            value: v.into(),
+            ctx: ctx.clock,
+        }
+    }
+
+    fn value_ctx(&self, v: &V) -> Option<VClock<A>> {
+        self.chain
+            .iter()
+            .find(|(_, value)| value == &v)
+            .map(|(ctx, _)| ctx.0.clone())
+    }
+
+    fn read(&self) -> ReadCtx<Vec<&V>, A> {
+        ReadCtx {
+            add_clock: self.clock.clone(),
+            rm_clock: self.clock.clone(),
+            val: self.chain.values().collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::quickcheck::{Arbitrary, Gen};
+    use crate::Dot;
+
+    #[test]
+    fn test_append() {
+        let mut chain: Chain<u8, _> = Default::default();
+        let read_ctx = chain.read();
+
+        let append_op = chain.append(1, read_ctx.derive_add_ctx("A"));
+        assert!(chain.validate_op(&append_op).is_ok());
+        chain.apply(append_op);
+
+        let read_ctx = chain.read();
+        assert_eq!(read_ctx.val, vec![&1]);
+        assert_eq!(read_ctx.add_clock, Dot::new("A", 1).into());
+
+        let append_op = chain.append(2, read_ctx.derive_add_ctx("B"));
+        assert!(chain.validate_op(&append_op).is_ok());
+        chain.apply(append_op);
+
+        let read_ctx = chain.read();
+        assert_eq!(read_ctx.val, vec![&1, &2]);
+        assert_eq!(
+            read_ctx.add_clock,
+            vec![Dot::new("A", 1), Dot::new("B", 1)]
+                .into_iter()
+                .collect()
+        );
+    }
+
+    // quickcheck! {
+    //     fn prop_chain_respects_clock_order(contexts: Vec<VClock<u8>>) -> TestResult {
+    //         let mut chain = Chain::default();
+
+    //         for (val, ctx) in contexts.iter().cloned().enumerate() {
+    //             let op = Op { val, ctx };
+    //             if chain.validate_op(&op).is_err() {
+    //                 return TestResult::discard();
+    //             }
+    //             chain.apply(&op)
+    //         }
+
+    //         let chain_vec = chain.read().val;
+
+    //         for index in chain_vec {
+    //             let index_ctx = chain.value_ctx(index).unwrap();
+    //             for index in chain_vec {
+    //                 let index_ctx = chain.value_ctx(index).unwrap();
+
+    //             }
+    //         }
+
+    //     }
+    // }
+}
+
+// TODO: replace `val` with `value`

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -126,11 +126,12 @@ impl<V: Eq, A: Ord + Clone + Debug> Chain<V, A> {
         }
     }
 
-    pub fn value_ctx(&self, v: &V) -> Option<VClock<A>> {
-        self.chain
-            .iter()
-            .find(|(_, value)| value == &v)
-            .map(|(ctx, _)| ctx.0.clone())
+    pub fn iter(&self) -> impl Iterator<Item = ReadCtx<&V, A>> {
+        self.chain.iter().map(move |(ctx, val)| ReadCtx {
+            add_clock: self.context_clock.clone(),
+            rm_clock: ctx.0.clone(),
+            val,
+        })
     }
 
     pub fn read(&self) -> ReadCtx<Vec<&V>, A> {
@@ -398,7 +399,6 @@ mod test {
                 }
             }
 
-            println!("Draining op queues {:#?}", op_queues);
             for (dest_actor, op_queue) in op_queues {
                 for (_source, queue) in op_queue {
                     for op in queue {

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -34,12 +34,7 @@ impl<A: Ord + Clone> Ord for Context<A> {
 
                 let largest_self = self_without_other.dots.keys().rev().next();
                 let largest_other = other_without_self.dots.keys().rev().next();
-                match (largest_self, largest_other) {
-                    (Some(self_actor), Some(other_actor)) => self_actor.cmp(&other_actor),
-                    (Some(_), None) => Ordering::Greater,
-                    (None, Some(_)) => Ordering::Less,
-                    (None, None) => Ordering::Equal,
-                }
+                largest_self.cmp(&largest_other)
             }
         }
     }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{CmRDT, Dot, VClock};
+use crate::VClock;
 
 /// ReadCtx's are used to extract data from CRDT's while maintaining some causal history.
 /// You should store ReadCtx's close to where mutation is exposed to the user.

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -27,8 +27,8 @@ pub struct AddCtx<A: Ord> {
     /// The adding vclock context
     pub clock: VClock<A>,
 
-    /// The Actor and the Actor's version at the time of the add
-    pub dot: Dot<A>,
+    /// The Actor who is adding with this context
+    pub actor: A,
 }
 
 /// RmCtx is used for mutations that remove information from a CRDT
@@ -41,16 +41,13 @@ pub struct RmCtx<A: Ord> {
 impl<V, A: Ord + Clone + Debug> ReadCtx<V, A> {
     /// Derives an AddCtx for a given actor from a ReadCtx
     pub fn derive_add_ctx(self, actor: A) -> AddCtx<A> {
-        let mut clock = self.add_clock;
-        let dot = clock.inc(actor);
-        clock.apply(dot.clone());
-        AddCtx { clock, dot }
+        let clock = self.add_clock;
+        AddCtx { clock, actor }
     }
 
     /// Derives a RmCtx from a ReadCtx
     pub fn derive_rm_ctx(self) -> RmCtx<A> {
-        RmCtx {
-            clock: self.rm_clock,
-        }
+        let clock = self.rm_clock;
+        RmCtx { clock }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@
 mod traits;
 pub use crate::traits::{Actor, CmRDT, CvRDT, ResetRemove};
 
+/// This module contains a Chain CRDT
+pub mod chain;
+
 /// This module contains a Last-Write-Wins Register.
 pub mod lwwreg;
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -366,7 +366,7 @@ impl<K: Ord, V: Val<A>, A: Ord + Hash + Clone> Map<K, V, A> {
         F: FnOnce(&V, AddCtx<A>) -> V::Op,
     {
         let key = key.into();
-        let dot = ctx.dot.clone();
+        let dot = ctx.clock.inc(ctx.actor.clone());
         let op = match self.entries.get(&key).map(|e| &e.val) {
             Some(data) => f(&data, ctx),
             None => f(&V::default(), ctx),

--- a/src/mvreg.rs
+++ b/src/mvreg.rs
@@ -182,10 +182,9 @@ impl<V, A: Ord + Clone + fmt::Debug> MVReg<V, A> {
 
     /// Set the value of the register
     pub fn write(&self, val: V, ctx: AddCtx<A>) -> Op<V, A> {
-        Op::Put {
-            clock: ctx.clock,
-            val,
-        }
+        let AddCtx { mut clock, actor } = ctx;
+        clock.apply(clock.inc(actor));
+        Op::Put { clock, val }
     }
 
     /// Consumes the register and returns the values

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -243,7 +243,7 @@ impl<M: Hash + Clone + Eq, A: Ord + Hash + Clone> Orswot<M, A> {
     /// Add a single element.
     pub fn add(&self, member: M, ctx: AddCtx<A>) -> Op<M, A> {
         Op::Add {
-            dot: ctx.dot,
+            dot: ctx.clock.inc(ctx.actor),
             members: std::iter::once(member).collect(),
         }
     }
@@ -251,7 +251,7 @@ impl<M: Hash + Clone + Eq, A: Ord + Hash + Clone> Orswot<M, A> {
     /// Add multiple elements.
     pub fn add_all<I: IntoIterator<Item = M>>(&self, members: I, ctx: AddCtx<A>) -> Op<M, A> {
         Op::Add {
-            dot: ctx.dot,
+            dot: ctx.clock.inc(ctx.actor),
             members: members.into_iter().collect(),
         }
     }


### PR DESCRIPTION
This is a POC for an append only CRDT.


The idea is to use VClock partial order when possible, and fall back to ordering by Actor when VClock's are concurrent.

Take the example below:

![chain-crdt-fork](https://user-images.githubusercontent.com/1832378/107325261-7a461d80-6a77-11eb-9dac-bd9b84bad20b.png)

 1. We start with the empty chain
 2. `A` then appends a<sub>1</sub> with context `{A1}`
 3. Then `B` and `C` concurrently append b<sub>1</sub> and c<sub>1</sub> respectively.

Note that B and C's context dominates A's context.

If we try to resolve the final chain order, it's clear that the chain begins with a<sub>1</sub>, ... but it's not clear how to order b<sub>1</sub> and c<sub>1</sub> since their contexts are concurrent ({A1, B1} is not bigger than {A1, C1} and vice-versa).

To resolve this ambiguity, we need a total order over the competing contexts. The rule used for this chain CRDT here is as follows:

1. first try to order by VClock's partial order, if that succeeds, use that ordering.
2. Otherwise, remove any dots that have been seen by the other side
3. sort the remaining dots by (Actor, Counter) for each side respectively.
4. Pairwise compare the two sorted sets to find the final ordering.

In our case, step 2. produces {A1, B1} => {B1} and {A1, C1} => {C1} since A1 has been seen by both sides.
Then we see that B's value will come before C's since B < C lexigraphically.

So the final sequence is a<sub>1</sub>, b<sub>1</sub>, c<sub>1</sub>.