### PR TITLE
add `split` helper method to `ReadCtx`

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -53,4 +53,16 @@ impl<V, A: Ord + Clone + Debug> ReadCtx<V, A> {
             clock: self.rm_clock,
         }
     }
+
+    /// Splits this ReadCtx into its data and an empty ReadCtx
+    pub fn split(self) -> (V, ReadCtx<(), A>) {
+        (
+            self.val,
+            ReadCtx {
+                add_clock: self.add_clock,
+                rm_clock: self.rm_clock,
+                val: (),
+            },
+        )
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -45,16 +45,16 @@ pub trait CmRDT {
     /// order over all ops.
     /// E.g.
     ///
-    /// Actor A produces ops A1, A2
-    /// Actor B produces ops B1, B2
+    /// * Actor A produces ops A1, A2
+    /// * Actor B produces ops B1, B2
     ///
     /// the only valid orderings are:
-    /// A1 < A2 < B1 < B2
-    /// A1 < B1 < A2 < B2
-    /// B1 < A1 < A2 < B2
-    /// A1 < B1 < B2 < A2
-    /// B1 < A1 < B2 < A2
-    /// B1 < B2 < A1 < A2
+    /// * A1 < A2 < B1 < B2
+    /// * A1 < B1 < A2 < B2
+    /// * B1 < A1 < A2 < B2
+    /// * A1 < B1 < B2 < A2
+    /// * B1 < A1 < B2 < A2
+    /// * B1 < B2 < A1 < A2
     ///
     /// Applying ops in any of the valid orders will converge to the same CRDT state
     ///


### PR DESCRIPTION
Hi,

this allows for simpler data processing without the need to clone the data (or write this fn by hand):

```rust
let (vals, read_ctx) = mvreg.read().split();
let sum = vals.into_iter().fold(0, |acc, val| acc + val);
let op = mvreg.write(sum, read_ctx.derive_add_ctx(1337));
mvreg.apply(op);
```

The https://github.com/rust-crdt/rust-crdt/commit/847a94ec0fbf054096639b21afd1c915f1e6da75 change made it so, that you can not derive a ctx and use the data by value.