### PR TITLE
Dense GList/List identifier

### DIFF
--- a/src/glist.rs
+++ b/src/glist.rs
@@ -6,101 +6,28 @@ use core::iter::FromIterator;
 use core::ops::Bound::*;
 use std::collections::BTreeSet;
 
-use num::{BigRational, One, Zero};
 use quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
 
-use crate::{CmRDT, CvRDT};
-
-/// Markers provide the main ordering component of our list.
-/// Entries in the list are ordered by lexigraphic order
-/// of (marker, elem). Elements themselves are tie-breakers
-/// in the case of conflicting markers.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Entry<T>(pub Vec<(BigRational, T)>);
-
-impl<T: Clone + Eq> Entry<T> {
-    /// Get a reference to the value this entry represents.
-    pub fn value(&self) -> &T {
-        self.0.last().map(|(_, elem)| elem).unwrap() // TODO: remove this unwrap
-    }
-
-    /// Get the value this entry represents, consuming the entry.
-    pub fn into_value(mut self) -> T {
-        self.0.pop().map(|(_, elem)| elem).unwrap() // TODO: remove this unwrap
-    }
-
-    /// Construct an entry between low and high holding the given element.
-    pub fn between(low: Option<&Self>, high: Option<&Self>, elem: T) -> Self {
-        match (low, high) {
-            (Some(low), Some(high)) => {
-                // Walk both paths until we reach a fork, constructing the path between these
-                // two entries as we go.
-
-                let mut path: Vec<(BigRational, T)> = vec![];
-                let low_path = low.0.iter().cloned();
-                let high_path = high.0.iter();
-                let mut lower_bound = None;
-                let mut upper_bound = None;
-                for (l, h) in low_path.zip(high_path) {
-                    if &l.0 == &h.0 {
-                        // The entry between low and high will share the common path between these two
-                        // entries. We accumulate this common prefix path as we traverse.
-                        path.push(l)
-                    } else {
-                        // We find a spot where the lower and upper paths fork.
-                        // We can insert our elem between these two bounds.
-                        lower_bound = Some(l.0);
-                        upper_bound = Some(&h.0);
-                        break;
-                    }
-                }
-                path.push((rational_between(lower_bound.as_ref(), upper_bound), elem));
-                Entry(path)
-            }
-
-            (low, high) => Entry(vec![(
-                rational_between(
-                    low.and_then(|low_entry| low_entry.0.first().map(|(r, _)| r)),
-                    high.and_then(|high_entry| high_entry.0.first().map(|(r, _)| r)),
-                ),
-                elem,
-            )]),
-        }
-    }
-}
-
-impl<T: fmt::Display> fmt::Display for Entry<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "E<")?;
-        let mut iter = self.0.iter();
-        if let Some((r, e)) = iter.next() {
-            write!(f, "{}:{}", r, e)?;
-        }
-        for (r, e) in iter {
-            write!(f, ", {}:{}", r, e)?;
-        }
-        write!(f, ">")
-    }
-}
+use crate::{CmRDT, CvRDT, Identifier};
 
 /// Operations that can be performed on a List
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Op<T> {
     /// Insert an element.
     Insert {
-        /// The Entry to insert.
-        entry: Entry<T>,
+        /// The element identifier to insert.
+        id: Identifier<T>,
     },
 }
 
 /// The GList is a grow-only list, that is, it allows inserts but not deletes.
-/// Entries in the list are paths through an ordered tree, the tree grows deeper
+/// Elements in the list are paths through an ordered tree, the tree grows deeper
 /// when we try to insert between two elements who were inserted concurrently and
 /// whose paths happen to have the same prefix.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GList<T: Ord> {
-    list: BTreeSet<Entry<T>>,
+    list: BTreeSet<Identifier<T>>,
 }
 
 impl<T: fmt::Display + Ord> fmt::Display for GList<T> {
@@ -133,48 +60,45 @@ impl<T: Ord + Clone> GList<T> {
 
     /// Read the elements of the list into a user defined container
     pub fn read<'a, C: FromIterator<&'a T>>(&'a self) -> C {
-        self.list.iter().map(|entry| entry.value()).collect()
+        self.list.iter().map(|id| id.value()).collect()
     }
 
     /// Read the elements of the list into a user defined container, consuming the list in the process.
     pub fn read_into<C: FromIterator<T>>(self) -> C {
-        self.list
-            .into_iter()
-            .map(|entry| entry.into_value())
-            .collect()
+        self.list.into_iter().map(|id| id.into_value()).collect()
     }
 
     /// Iterate over the elements of the list
-    pub fn iter(&self) -> std::collections::btree_set::Iter<Entry<T>> {
+    pub fn iter(&self) -> std::collections::btree_set::Iter<Identifier<T>> {
         self.list.iter()
     }
 
     /// Return the element and it's marker at the specified index
-    pub fn get(&self, idx: usize) -> Option<&Entry<T>> {
+    pub fn get(&self, idx: usize) -> Option<&Identifier<T>> {
         self.list.iter().nth(idx)
     }
 
     /// Generate an Op to insert the given element before the given marker
-    pub fn insert_before(&self, high_entry_opt: Option<&Entry<T>>, elem: T) -> Op<T> {
-        let low_entry_opt = high_entry_opt.and_then(|high_entry| {
+    pub fn insert_before(&self, high_id_opt: Option<&Identifier<T>>, elem: T) -> Op<T> {
+        let low_id_opt = high_id_opt.and_then(|high_id| {
             self.list
-                .range((Unbounded, Excluded(high_entry.clone())))
+                .range((Unbounded, Excluded(high_id.clone())))
                 .rev()
-                .find(|entry| entry < &high_entry)
+                .find(|id| id < &high_id)
         });
-        let entry = Entry::between(low_entry_opt, high_entry_opt, elem);
-        Op::Insert { entry }
+        let id = Identifier::between(low_id_opt, high_id_opt, elem);
+        Op::Insert { id }
     }
 
     /// Generate an insert op to insert the given element after the given marker
-    pub fn insert_after(&self, low_entry_opt: Option<&Entry<T>>, elem: T) -> Op<T> {
-        let high_entry_opt = low_entry_opt.and_then(|low_entry| {
+    pub fn insert_after(&self, low_id_opt: Option<&Identifier<T>>, elem: T) -> Op<T> {
+        let high_id_opt = low_id_opt.and_then(|low_id| {
             self.list
-                .range((Excluded(low_entry.clone()), Unbounded))
-                .find(|entry| entry > &low_entry)
+                .range((Excluded(low_id.clone()), Unbounded))
+                .find(|id| id > &low_id)
         });
-        let entry = Entry::between(low_entry_opt, high_entry_opt, elem);
-        Op::Insert { entry }
+        let id = Identifier::between(low_id_opt, high_id_opt, elem);
+        Op::Insert { id }
     }
 
     /// Get the length of the list.
@@ -188,12 +112,12 @@ impl<T: Ord + Clone> GList<T> {
     }
 
     /// Get first element of the sequence represented by the list.
-    pub fn first(&self) -> Option<&Entry<T>> {
+    pub fn first(&self) -> Option<&Identifier<T>> {
         self.iter().next()
     }
 
     /// Get last element of the sequence represented by the list.
-    pub fn last(&self) -> Option<&Entry<T>> {
+    pub fn last(&self) -> Option<&Identifier<T>> {
         self.iter().rev().next()
     }
 }
@@ -208,7 +132,7 @@ impl<T: Ord> CmRDT for GList<T> {
 
     fn apply(&mut self, op: Self::Op) {
         match op {
-            Op::Insert { entry } => self.list.insert(entry),
+            Op::Insert { id } => self.list.insert(id),
         };
     }
 }
@@ -225,35 +149,9 @@ impl<T: Ord> CvRDT for GList<T> {
     }
 }
 
-impl<T: Arbitrary> Arbitrary for Entry<T> {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let mut path = vec![];
-        for _ in 0..(u8::arbitrary(g) % 7) {
-            let ordering_index_material: Vec<(i64, i64)> = Arbitrary::arbitrary(g);
-            let ordering_index = ordering_index_material
-                .into_iter()
-                .filter(|(_, d)| d != &0)
-                .take(3)
-                .map(|(n, d)| BigRational::new(n.into(), d.into()))
-                .sum();
-            path.push((ordering_index, T::arbitrary(g)));
-        }
-        Entry(path)
-    }
-}
-
 impl<T: Arbitrary> Arbitrary for Op<T> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let entry = Entry::arbitrary(g);
-        Op::Insert { entry }
-    }
-}
-
-fn rational_between(low: Option<&BigRational>, high: Option<&BigRational>) -> BigRational {
-    match (low, high) {
-        (None, None) => BigRational::zero(),
-        (Some(low), None) => low + BigRational::one(),
-        (None, Some(high)) => high - BigRational::one(),
-        (Some(low), Some(high)) => (low + high) / BigRational::from_integer(2.into()),
+        let id = Identifier::arbitrary(g);
+        Op::Insert { id }
     }
 }

--- a/src/glist.rs
+++ b/src/glist.rs
@@ -6,7 +6,7 @@ use core::iter::FromIterator;
 use core::ops::Bound::*;
 use std::collections::BTreeSet;
 
-use num::{BigInt, BigRational, One, Zero};
+use num::{BigRational, One, Zero};
 use quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
 
@@ -16,63 +16,105 @@ use crate::{CmRDT, CvRDT};
 /// Entries in the list are ordered by lexigraphic order
 /// of (marker, elem). Elements themselves are tie-breakers
 /// in the case of conflicting markers.
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Marker(BigRational);
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Entry<T>(pub Vec<(BigRational, T)>);
 
-impl Marker {
-    fn between(low: Option<&Self>, high: Option<&Self>) -> Self {
+impl<T: Clone + Eq> Entry<T> {
+    /// Get a reference to the value this entry represents.
+    pub fn value(&self) -> &T {
+        self.0.last().map(|(_, elem)| elem).unwrap() // TODO: remove this unwrap
+    }
+
+    /// Get the value this entry represents, consuming the entry.
+    pub fn into_value(mut self) -> T {
+        self.0.pop().map(|(_, elem)| elem).unwrap() // TODO: remove this unwrap
+    }
+
+    /// Construct an entry between low and high holding the given element.
+    pub fn between(low: Option<&Self>, high: Option<&Self>, elem: T) -> Self {
         match (low, high) {
-            (None, None) => Default::default(),
-            (Some(low), None) => Marker(&low.0 + &BigRational::one()),
-            (None, Some(high)) => Marker(&high.0 - &BigRational::one()),
             (Some(low), Some(high)) => {
-                Marker((&low.0 + &high.0) / BigRational::from_integer(2.into()))
+                // Walk both paths until we reach a fork, constructing the path between these
+                // two entries as we go.
+
+                let mut path: Vec<(BigRational, T)> = vec![];
+                let low_path = low.0.iter().cloned();
+                let high_path = high.0.iter();
+                let mut lower_bound = None;
+                let mut upper_bound = None;
+                for (l, h) in low_path.zip(high_path) {
+                    if &l.0 == &h.0 {
+                        // The entry between low and high will share the common path between these two
+                        // entries. We accumulate this common prefix path as we traverse.
+                        path.push(l)
+                    } else {
+                        // We find a spot where the lower and upper paths fork.
+                        // We can insert our elem between these two bounds.
+                        lower_bound = Some(l.0);
+                        upper_bound = Some(&h.0);
+                        break;
+                    }
+                }
+                path.push((rational_between(lower_bound.as_ref(), upper_bound), elem));
+                Entry(path)
             }
+
+            (low, high) => Entry(vec![(
+                rational_between(
+                    low.and_then(|low_entry| low_entry.0.first().map(|(r, _)| r)),
+                    high.and_then(|high_entry| high_entry.0.first().map(|(r, _)| r)),
+                ),
+                elem,
+            )]),
         }
     }
 }
 
-impl<N: Into<BigInt>> From<N> for Marker {
-    fn from(n: N) -> Self {
-        Marker(BigRational::from_integer(n.into()))
-    }
-}
-
-impl fmt::Debug for Marker {
+impl<T: fmt::Display> fmt::Display for Entry<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl fmt::Display for Marker {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "M{}", self.0)
-    }
-}
-
-impl Default for Marker {
-    fn default() -> Self {
-        Marker(BigRational::zero())
+        write!(f, "E<")?;
+        let mut iter = self.0.iter();
+        if let Some((r, e)) = iter.next() {
+            write!(f, "{}:{}", r, e)?;
+        }
+        for (r, e) in iter {
+            write!(f, ", {}:{}", r, e)?;
+        }
+        write!(f, ">")
     }
 }
 
 /// Operations that can be performed on a List
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Op<T> {
-    /// Insert an element
+    /// Insert an element.
     Insert {
-        /// Ordering marker
-        marker: Marker,
-        /// Element to insert
-        elem: T,
+        /// The Entry to insert.
+        entry: Entry<T>,
     },
 }
 
 /// The GList is a grow-only list, that is, it allows inserts but not deletes.
-/// It is similar to the GSet, with each element tagged with an ordering marker.
+/// Entries in the list are paths through an ordered tree, the tree grows deeper
+/// when we try to insert between two elements who were inserted concurrently and
+/// whose paths happen to have the same prefix.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GList<T: Ord> {
-    list: BTreeSet<(Marker, T)>,
+    list: BTreeSet<Entry<T>>,
+}
+
+impl<T: fmt::Display + Ord> fmt::Display for GList<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "GList[")?;
+        let mut iter = self.list.iter();
+        if let Some(e) = iter.next() {
+            write!(f, "{}", e)?;
+        }
+        for e in iter {
+            write!(f, "{}", e)?;
+        }
+        write!(f, "]")
+    }
 }
 
 impl<T: Ord> Default for GList<T> {
@@ -89,44 +131,50 @@ impl<T: Ord + Clone> GList<T> {
         Self::default()
     }
 
-    /// Read the elements of the list
-    pub fn read<C: FromIterator<T>>(self) -> C {
-        self.list.into_iter().map(|(_, e)| e).collect()
+    /// Read the elements of the list into a user defined container
+    pub fn read<'a, C: FromIterator<&'a T>>(&'a self) -> C {
+        self.list.iter().map(|entry| entry.value()).collect()
+    }
+
+    /// Read the elements of the list into a user defined container, consuming the list in the process.
+    pub fn read_into<C: FromIterator<T>>(self) -> C {
+        self.list
+            .into_iter()
+            .map(|entry| entry.into_value())
+            .collect()
     }
 
     /// Iterate over the elements of the list
-    pub fn iter(&self) -> std::collections::btree_set::Iter<(Marker, T)> {
+    pub fn iter(&self) -> std::collections::btree_set::Iter<Entry<T>> {
         self.list.iter()
     }
 
     /// Return the element and it's marker at the specified index
-    pub fn get(&self, idx: usize) -> Option<&(Marker, T)> {
+    pub fn get(&self, idx: usize) -> Option<&Entry<T>> {
         self.list.iter().nth(idx)
     }
 
     /// Generate an Op to insert the given element before the given marker
-    pub fn insert_before(&self, high_marker_opt: Option<&Marker>, elem: T) -> Op<T> {
-        let low_marker_opt = high_marker_opt.and_then(|high_marker| {
+    pub fn insert_before(&self, high_entry_opt: Option<&Entry<T>>, elem: T) -> Op<T> {
+        let low_entry_opt = high_entry_opt.and_then(|high_entry| {
             self.list
-                .range((Unbounded, Excluded((high_marker.clone(), elem.clone()))))
+                .range((Unbounded, Excluded(high_entry.clone())))
                 .rev()
-                .map(|(marker, _)| marker)
-                .find(|marker| marker < &high_marker)
+                .find(|entry| entry < &high_entry)
         });
-        let marker = Marker::between(low_marker_opt, high_marker_opt);
-        Op::Insert { marker, elem }
+        let entry = Entry::between(low_entry_opt, high_entry_opt, elem);
+        Op::Insert { entry }
     }
 
     /// Generate an insert op to insert the given element after the given marker
-    pub fn insert_after(&self, low_marker_opt: Option<&Marker>, elem: T) -> Op<T> {
-        let high_marker_opt = low_marker_opt.and_then(|low_marker| {
+    pub fn insert_after(&self, low_entry_opt: Option<&Entry<T>>, elem: T) -> Op<T> {
+        let high_entry_opt = low_entry_opt.and_then(|low_entry| {
             self.list
-                .range((Excluded((low_marker.clone(), elem.clone())), Unbounded))
-                .map(|(marker, _)| marker)
-                .find(|marker| marker > &low_marker)
+                .range((Excluded(low_entry.clone()), Unbounded))
+                .find(|entry| entry > &low_entry)
         });
-        let marker = Marker::between(low_marker_opt, high_marker_opt);
-        Op::Insert { marker, elem }
+        let entry = Entry::between(low_entry_opt, high_entry_opt, elem);
+        Op::Insert { entry }
     }
 
     /// Get the length of the list.
@@ -140,12 +188,12 @@ impl<T: Ord + Clone> GList<T> {
     }
 
     /// Get first element of the sequence represented by the list.
-    pub fn first(&self) -> Option<&(Marker, T)> {
+    pub fn first(&self) -> Option<&Entry<T>> {
         self.iter().next()
     }
 
     /// Get last element of the sequence represented by the list.
-    pub fn last(&self) -> Option<&(Marker, T)> {
+    pub fn last(&self) -> Option<&Entry<T>> {
         self.iter().rev().next()
     }
 }
@@ -160,7 +208,7 @@ impl<T: Ord> CmRDT for GList<T> {
 
     fn apply(&mut self, op: Self::Op) {
         match op {
-            Op::Insert { marker, elem } => self.list.insert((marker, elem)),
+            Op::Insert { entry } => self.list.insert(entry),
         };
     }
 }
@@ -177,23 +225,35 @@ impl<T: Ord> CvRDT for GList<T> {
     }
 }
 
-impl Arbitrary for Marker {
+impl<T: Arbitrary> Arbitrary for Entry<T> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let marker_material: Vec<(i64, i64)> = Arbitrary::arbitrary(g);
-        let marker = marker_material
-            .into_iter()
-            .filter(|(_, d)| d != &0)
-            .take(3)
-            .map(|(n, d)| BigRational::new(n.into(), d.into()))
-            .sum();
-        Marker(marker)
+        let mut path = vec![];
+        for _ in 0..(u8::arbitrary(g) % 7) {
+            let ordering_index_material: Vec<(i64, i64)> = Arbitrary::arbitrary(g);
+            let ordering_index = ordering_index_material
+                .into_iter()
+                .filter(|(_, d)| d != &0)
+                .take(3)
+                .map(|(n, d)| BigRational::new(n.into(), d.into()))
+                .sum();
+            path.push((ordering_index, T::arbitrary(g)));
+        }
+        Entry(path)
     }
 }
 
 impl<T: Arbitrary> Arbitrary for Op<T> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let marker = Marker::arbitrary(g);
-        let elem = T::arbitrary(g);
-        Op::Insert { marker, elem }
+        let entry = Entry::arbitrary(g);
+        Op::Insert { entry }
+    }
+}
+
+fn rational_between(low: Option<&BigRational>, high: Option<&BigRational>) -> BigRational {
+    match (low, high) {
+        (None, None) => BigRational::zero(),
+        (Some(low), None) => low + BigRational::one(),
+        (None, Some(high)) => high - BigRational::one(),
+        (Some(low), Some(high)) => (low + high) / BigRational::from_integer(2.into()),
     }
 }

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -1,0 +1,152 @@
+//! Dense Identifiers.
+//!
+//! It's sometimes usefult to be able to create identifiers for which we know there
+//! is always space between values to create another.
+
+//! That is, if we have identifiers `a`, `b` with `a != b` then we can always construct
+//! an  identifier `c` s.t. `a < c < b` or `a > c > b`.
+//!
+//! The GList and List CRDT's rely on this property so that we may always insert elements
+//! between any existing elements.
+use core::fmt;
+
+use num::{BigRational, One, Zero};
+use quickcheck::{Arbitrary, Gen};
+use serde::{Deserialize, Serialize};
+
+fn rational_between(low: Option<&BigRational>, high: Option<&BigRational>) -> BigRational {
+    match (low, high) {
+        (None, None) => BigRational::zero(),
+        (Some(low), None) => low + BigRational::one(),
+        (None, Some(high)) => high - BigRational::one(),
+        (Some(low), Some(high)) => (low + high) / BigRational::from_integer(2.into()),
+    }
+}
+
+/// A dense Identifier, if you have two identifiers that are different, we can
+/// always construct an identifier between them.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Identifier<T>(pub Vec<(BigRational, T)>);
+
+impl<T: Clone + Eq> Identifier<T> {
+    /// Get a reference to the value this entry represents.
+    pub fn value(&self) -> &T {
+        self.0.last().map(|(_, elem)| elem).unwrap() // TODO: remove this unwrap
+    }
+
+    /// Get the value this entry represents, consuming the entry.
+    pub fn into_value(mut self) -> T {
+        self.0.pop().map(|(_, elem)| elem).unwrap() // TODO: remove this unwrap
+    }
+
+    /// Construct an entry between low and high holding the given element.
+    pub fn between(low: Option<&Self>, high: Option<&Self>, elem: T) -> Self {
+        match (low, high) {
+            (Some(low), Some(high)) => {
+                // Walk both paths until we reach a fork, constructing the path between these
+                // two entries as we go.
+
+                let mut path: Vec<(BigRational, T)> = vec![];
+                let low_path = low.0.iter().cloned();
+                let high_path = high.0.iter();
+                let mut lower_bound = None;
+                let mut upper_bound = None;
+                for (l, h) in low_path.zip(high_path) {
+                    if &l.0 == &h.0 {
+                        // The entry between low and high will share the common path between these two
+                        // entries. We accumulate this common prefix path as we traverse.
+                        path.push(l)
+                    } else {
+                        // We find a spot where the lower and upper paths fork.
+                        // We can insert our elem between these two bounds.
+                        lower_bound = Some(l.0);
+                        upper_bound = Some(&h.0);
+                        break;
+                    }
+                }
+                path.push((rational_between(lower_bound.as_ref(), upper_bound), elem));
+                Self(path)
+            }
+
+            (low, high) => Self(vec![(
+                rational_between(
+                    low.and_then(|low_entry| low_entry.0.first().map(|(r, _)| r)),
+                    high.and_then(|high_entry| high_entry.0.first().map(|(r, _)| r)),
+                ),
+                elem,
+            )]),
+        }
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Identifier<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ID[")?;
+        let mut iter = self.0.iter();
+        if let Some((r, e)) = iter.next() {
+            write!(f, "{}:{}", r, e)?;
+        }
+        for (r, e) in iter {
+            write!(f, ", {}:{}", r, e)?;
+        }
+        write!(f, "]")
+    }
+}
+
+impl<T: Arbitrary> Arbitrary for Identifier<T> {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let mut path = vec![];
+        for _ in 0..(u8::arbitrary(g) % 7) {
+            let ordering_index_material: Vec<(i64, i64)> = Arbitrary::arbitrary(g);
+            let ordering_index = ordering_index_material
+                .into_iter()
+                .filter(|(_, d)| d != &0)
+                .take(3)
+                .map(|(n, d)| BigRational::new(n.into(), d.into()))
+                .sum();
+            path.push((ordering_index, T::arbitrary(g)));
+        }
+        Self(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::TestResult;
+    use quickcheck_macros::quickcheck;
+
+    #[quickcheck]
+    fn id_is_dense(id_a: Identifier<u8>, id_b: Identifier<u8>, elem: u8) -> TestResult {
+        if id_a.0.is_empty() || id_b.0.is_empty() {
+            return TestResult::discard();
+        }
+        let (id_min, id_max) = if id_a < id_b {
+            (id_a, id_b)
+        } else {
+            (id_b, id_a)
+        };
+
+        let id_mid = Identifier::between(Some(&id_min), Some(&id_max), elem);
+        assert!(id_min < id_mid);
+        assert!(id_mid < id_max);
+        TestResult::passed()
+    }
+
+    #[test]
+    fn test_id_is_dense() {
+        let id_a = Identifier(vec![(BigRational::from_integer((-1000).into()), 65)]);
+        let id_b = Identifier(vec![]);
+        let elem = 0;
+        let (id_min, id_max) = if id_a < id_b {
+            (id_a, id_b)
+        } else {
+            (id_b, id_a)
+        };
+
+        let id_mid = Identifier::between(Some(&id_min), Some(&id_max), elem);
+        println!("mid: {}", id_mid);
+        assert!(id_min < id_mid);
+        assert!(id_mid < id_max);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,9 @@ pub mod vvwe;
 
 /// Top-level re-exports for CRDT structures.
 pub use crate::{
-    dot::Dot, dot::DotRange, gcounter::GCounter, gset::GSet, identifier::Identifier,
-    lwwreg::LWWReg, map::Map, mvreg::MVReg, orswot::Orswot, pncounter::PNCounter, vclock::VClock,
+    dot::Dot, dot::DotRange, dot::OrdDot, gcounter::GCounter, gset::GSet, identifier::Identifier,
+    list::List, lwwreg::LWWReg, map::Map, mvreg::MVReg, orswot::Orswot, pncounter::PNCounter,
+    vclock::VClock,
 };
 
 /// A re-export of the quickcheck crate for use in property based testing of user code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ pub mod vclock;
 /// This module contains the Dot (Actor + Sequence Number)
 pub mod dot;
 
+/// This module contains a dense Identifier.
+pub mod identifier;
+
 /// This module contains an Observed-Remove Set With Out Tombstones.
 pub mod orswot;
 
@@ -54,8 +57,8 @@ pub mod vvwe;
 
 /// Top-level re-exports for CRDT structures.
 pub use crate::{
-    dot::Dot, dot::DotRange, gcounter::GCounter, gset::GSet, lwwreg::LWWReg, map::Map,
-    mvreg::MVReg, orswot::Orswot, pncounter::PNCounter, vclock::VClock,
+    dot::Dot, dot::DotRange, gcounter::GCounter, gset::GSet, identifier::Identifier,
+    lwwreg::LWWReg, map::Map, mvreg::MVReg, orswot::Orswot, pncounter::PNCounter, vclock::VClock,
 };
 
 /// A re-export of the quickcheck crate for use in property based testing of user code

--- a/test/glist.rs
+++ b/test/glist.rs
@@ -1,8 +1,7 @@
 use num::BigRational;
 
-use crdts::glist::{Entry, GList, Op};
-use crdts::{CmRDT, CvRDT};
-use quickcheck::TestResult;
+use crdts::glist::{GList, Op};
+use crdts::{CmRDT, CvRDT, Identifier};
 use quickcheck_macros::quickcheck;
 
 #[test]
@@ -33,9 +32,9 @@ fn test_append_increments_entry() {
     glist.apply(glist.insert_after(glist.last(), 'c'));
     assert_eq!(
         vec![
-            Entry(vec![(BigRational::from_integer(0.into()), 'a')]),
-            Entry(vec![(BigRational::from_integer(1.into()), 'b')]),
-            Entry(vec![(BigRational::from_integer(2.into()), 'c')]),
+            Identifier::from((BigRational::from_integer(0.into()), 'a')),
+            Identifier::from((BigRational::from_integer(1.into()), 'b')),
+            Identifier::from((BigRational::from_integer(2.into()), 'c')),
         ],
         glist.iter().cloned().collect::<Vec<_>>()
     );
@@ -215,21 +214,4 @@ fn prop_validate_against_vec_model(plan: Vec<(usize, u8, bool)>) {
         }
     }
     assert_eq!(model, glist.read_into::<Vec<u8>>());
-}
-
-#[quickcheck]
-fn entry_is_dense(entry_a: Entry<u8>, entry_b: Entry<u8>, elem: u8) -> TestResult {
-    if entry_a.0.is_empty() || entry_b.0.is_empty() {
-        return TestResult::discard();
-    }
-    let (entry_min, entry_max) = if entry_a < entry_b {
-        (entry_a, entry_b)
-    } else {
-        (entry_b, entry_a)
-    };
-
-    let entry_mid = Entry::between(Some(&entry_min), Some(&entry_max), elem);
-    assert!(entry_min < entry_mid);
-    assert!(entry_mid < entry_max);
-    TestResult::passed()
 }


### PR DESCRIPTION
The GList and List didn't have dense identifiers as implemented, this could cause failures to insert elements at desired indices. This PR fixes this bug by creating properly dense identifiers. We had this functionality with the previous LSeq impl. but it was a regression when we moved to the List CRDT type.