### PR TITLE
Flip MerkleReg DAG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crdts"
 description = "Practical, serializable, thoroughly tested CRDTs"
-version = "6.3.3"
+version = "7.0.0"
 authors = ["Tyler Neely <t@jujit.su>", "David Rusu <davidrusu.me@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-crdt/rust-crdt"

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,6 @@
-
-let
-    pkgs = import <nixpkgs> {};
-in 
-pkgs.stdenv.mkDerivation {
-  name = "crdts";
-    buildInputs = [
-      (pkgs.rustChannelOf { channel = "stable"; }).rust
-    ];
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    cargo
+  ];
 }

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -74,10 +74,10 @@ impl<T: Clone + Ord + Eq> Identifier<T> {
     pub fn between(low: Option<&Self>, high: Option<&Self>, marker: T) -> Self {
         match (low, high) {
             (Some(low), Some(high)) => {
-                if low > high {
-                    return Self::between(Some(high), Some(low), marker);
-                } else if low == high {
-                    return high.clone();
+                match low.cmp(high) {
+                    Ordering::Greater => return Self::between(Some(high), Some(low), marker),
+                    Ordering::Equal => return high.clone(),
+                    _ => (),
                 }
 
                 // Walk both paths until we reach a fork, constructing the path between these
@@ -162,7 +162,8 @@ impl<T: Arbitrary> Arbitrary for Identifier<T> {
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
         let mut path = self.0.clone();
-        if let Some(_) = path.pop() {
+        let last_elem_opt = path.pop();
+        if last_elem_opt.is_some() {
             Box::new(std::iter::once(Self(path)))
         } else {
             Box::new(std::iter::empty())

--- a/src/merkle_reg.rs
+++ b/src/merkle_reg.rs
@@ -112,7 +112,7 @@ impl<T> MerkleReg<T> {
 
     /// Write the given value on top of the given children.
     pub fn write(&self, value: T, children: BTreeSet<Hash>) -> Node<T> {
-        Node { value, children }
+        Node { children, value }
     }
 
     /// Retrieve a node in the Merkle DAG by it's hash.

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -254,7 +254,7 @@ impl<A: Ord> VClock<A> {
     /// assert_eq!(c.get(&43), 0);
     /// ```
     pub fn glb(&mut self, other: &Self) {
-        self.dots = mem::replace(&mut self.dots, BTreeMap::new())
+        self.dots = mem::take(&mut self.dots)
             .into_iter()
             .filter_map(|(actor, count)| {
                 // Since an actor missing from the dots map has an implied

--- a/test/merkle_reg.rs
+++ b/test/merkle_reg.rs
@@ -43,25 +43,25 @@ fn test_traverse_reg_history() {
 
     let node_c = nodes.pop().unwrap();
 
-    // check parents of node_c
-    let parents = reg.parents(node_c.hash());
-    assert_eq!(parents.hashes_and_nodes().count(), 2);
+    // check children of node_c
+    let children = reg.children(node_c.hash());
+    assert_eq!(children.hashes_and_nodes().count(), 2);
 
-    let mut hashes_and_nodes = parents.hashes_and_nodes();
-    let (parent_1, _) = hashes_and_nodes.next().unwrap();
-    let (parent_2, _) = hashes_and_nodes.next().unwrap();
-    assert_eq!(reg.node(parent_1).unwrap().value, "a");
-    assert_eq!(reg.node(parent_2).unwrap().value, "b");
+    let mut hashes_and_nodes = children.hashes_and_nodes();
+    let (child_1, _) = hashes_and_nodes.next().unwrap();
+    let (child_2, _) = hashes_and_nodes.next().unwrap();
+    assert_eq!(reg.node(child_1).unwrap().value, "a");
+    assert_eq!(reg.node(child_2).unwrap().value, "b");
 
-    // check children of node_a and node_b is node_c
-    let a_children = reg.children(a.hash());
-    let b_children = reg.children(b.hash());
+    // check parents of node_a and node_b is node_c
+    let a_parents = reg.parents(a.hash());
+    let b_parents = reg.parents(b.hash());
 
-    assert_eq!(a_children.hashes_and_nodes().count(), 1);
-    assert_eq!(b_children.hashes_and_nodes().count(), 1);
+    assert_eq!(a_parents.hashes_and_nodes().count(), 1);
+    assert_eq!(b_parents.hashes_and_nodes().count(), 1);
 
-    let a_hash_and_node = a_children.hashes_and_nodes().next().unwrap();
-    let b_hash_and_node = b_children.hashes_and_nodes().next().unwrap();
+    let a_hash_and_node = a_parents.hashes_and_nodes().next().unwrap();
+    let b_hash_and_node = b_parents.hashes_and_nodes().next().unwrap();
     assert_eq!(a_hash_and_node, b_hash_and_node);
     assert_eq!(reg.node(a_hash_and_node.0).unwrap().value, "c");
 }


### PR DESCRIPTION
I had gotten the DAG upside down, lets follow the original description of the Merkle DAG[0] and flip ours.

This PR renames:

- leaves => roots
- parents => children

[0] https://docs.ipfs.io/concepts/merkle-dag/