### PR TITLE
Feature flags for disabling heavy dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --release
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --examples
+          args: --examples --release
 
       - uses: actions-rs/cargo@v1
         with:
@@ -39,3 +39,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/rust-crdt/rust-crdt"
 repository = "https://github.com/rust-crdt/rust-crdt"
 documentation = "https://docs.rs/crdts"
 keywords = ["crdt", "data-structures", "distributed-systems", "vector-clock", "riak"]
-edition = "2018"
+edition = "2021"
 resolver = "2"
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,25 @@ repository = "https://github.com/rust-crdt/rust-crdt"
 documentation = "https://docs.rs/crdts"
 keywords = ["crdt", "data-structures", "distributed-systems", "vector-clock", "riak"]
 edition = "2018"
+resolver = "2"
 
 [[test]]
 name = "test"
 path = "test/test.rs"
 
+[features]
+default = ["quickcheck"]
+quickcheck = ["dep:quickcheck"]
+
 [dependencies]
 num = {version = "0.3.1", features = ["serde"]}
 serde = { version = "~1.0.91", features = ["derive"] }
 rand = "0.7"
-quickcheck = "0.9"
+quickcheck = {version = "0.9", optional = true}
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 
 [dev-dependencies]
+crdts = { path = ".", features = ["quickcheck"] }
 quickcheck_macros = "0.9"
 derive_more = "0.99"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crdts"
 description = "Practical, serializable, thoroughly tested CRDTs"
-version = "7.0.0"
+version = "7.1.0"
 authors = ["Tyler Neely <t@jujit.su>", "David Rusu <davidrusu.me@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-crdt/rust-crdt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,20 +16,27 @@ name = "test"
 path = "test/test.rs"
 
 [features]
-default = ["quickcheck"]
+default = ["quickcheck", "num", "merkle"]
 quickcheck = ["dep:quickcheck"]
+num = ["dep:num"]
+merkle = ["dep:tiny-keccak"]
 
 [dependencies]
-num = {version = "0.3.1", features = ["serde"]}
 serde = { version = "~1.0.91", features = ["derive"] }
-rand = "0.7"
+
+# glist, list, pncounter, gcounter
+num = {version = "0.3.1", features = ["serde"], optional = true}
+
+# merkle-reg
+tiny-keccak = { version = "2.0.2", features = ["sha3"], optional = true }
+
+# testing
 quickcheck = {version = "0.9", optional = true}
-tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 
 [dev-dependencies]
-crdts = { path = ".", features = ["quickcheck"] }
 quickcheck_macros = "0.9"
 derive_more = "0.99"
+rand = "0.7"
 
 [profile.release]
 debug = true

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -4,8 +4,6 @@ use std::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Serialize};
 
-use crate::quickcheck::{Arbitrary, Gen};
-
 /// Dot is a version marker for a single actor
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Dot<A> {
@@ -76,6 +74,10 @@ impl<A> From<(A, u64)> for Dot<A> {
     }
 }
 
+#[cfg(feature = "quickcheck")]
+use quickcheck::{Arbitrary, Gen};
+
+#[cfg(feature = "quickcheck")]
 impl<A: Arbitrary + Clone> Arbitrary for Dot<A> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         Dot {

--- a/src/glist.rs
+++ b/src/glist.rs
@@ -6,7 +6,6 @@ use core::iter::FromIterator;
 use core::ops::Bound::*;
 use std::collections::BTreeSet;
 
-use quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
 
 use crate::{CmRDT, CvRDT, Identifier};
@@ -149,6 +148,10 @@ impl<T: Ord> CvRDT for GList<T> {
     }
 }
 
+#[cfg(feature = "quickcheck")]
+use quickcheck::{Arbitrary, Gen};
+
+#[cfg(feature = "quickcheck")]
 impl<T: Arbitrary> Arbitrary for Op<T> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let id = Identifier::arbitrary(g);

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -12,7 +12,6 @@ use core::cmp::Ordering;
 use core::fmt;
 
 use num::{BigRational, One, Zero};
-use quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
 
 fn rational_between(low: Option<&BigRational>, high: Option<&BigRational>) -> BigRational {
@@ -144,6 +143,10 @@ impl<T: fmt::Display> fmt::Display for Identifier<T> {
     }
 }
 
+#[cfg(feature = "quickcheck")]
+use quickcheck::{Arbitrary, Gen};
+
+#[cfg(feature = "quickcheck")]
 impl<T: Arbitrary> Arbitrary for Identifier<T> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let mut path = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod lwwreg;
 pub mod mvreg;
 
 /// This module contains a Merkle-Dag Register.
+#[cfg(feature = "merkle")]
 pub mod merkle_reg;
 
 /// This module contains the Vector Clock
@@ -30,21 +31,25 @@ pub mod vclock;
 pub mod dot;
 
 /// This module contains a dense Identifier.
+#[cfg(feature = "num")]
 pub mod identifier;
 
 /// This module contains an Observed-Remove Set With Out Tombstones.
 pub mod orswot;
 
 /// This module contains a Grow-only Counter.
+#[cfg(feature = "num")]
 pub mod gcounter;
 
 /// This module contains a Grow-only Set.
 pub mod gset;
 
 /// This module contains a Grow-only List.
+#[cfg(feature = "num")]
 pub mod glist;
 
 /// This module contains a Positive-Negative Counter.
+#[cfg(feature = "num")]
 pub mod pncounter;
 
 /// This module contains a Map with Reset-Remove and Observed-Remove semantics.
@@ -54,18 +59,23 @@ pub mod map;
 pub mod ctx;
 
 /// This module contains a Sequence.
+#[cfg(feature = "num")]
 pub mod list;
+
+#[cfg(feature = "num")]
+pub use {
+    gcounter::GCounter, glist::GList, identifier::Identifier, list::List, pncounter::PNCounter,
+};
 
 // /// Version Vector with Exceptions
 // pub mod vvwe;
 
 /// Top-level re-exports for CRDT structures.
 pub use crate::{
-    dot::Dot, dot::DotRange, dot::OrdDot, gcounter::GCounter, gset::GSet, identifier::Identifier,
-    list::List, lwwreg::LWWReg, map::Map, mvreg::MVReg, orswot::Orswot, pncounter::PNCounter,
-    vclock::VClock,
+    dot::Dot, dot::DotRange, dot::OrdDot, gset::GSet, lwwreg::LWWReg, map::Map, mvreg::MVReg,
+    orswot::Orswot, vclock::VClock,
 };
 
-/// A re-export of the quickcheck crate for use in property based testing of user code
+/// A re-export of the quickcheck crate for external property tests
 #[cfg(feature = "quickcheck")]
 pub use quickcheck;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,8 @@ pub mod ctx;
 /// This module contains a Sequence.
 pub mod list;
 
-/// Version Vector with Exceptions
-pub mod vvwe;
+// /// Version Vector with Exceptions
+// pub mod vvwe;
 
 /// Top-level re-exports for CRDT structures.
 pub use crate::{
@@ -67,4 +67,5 @@ pub use crate::{
 };
 
 /// A re-export of the quickcheck crate for use in property based testing of user code
+#[cfg(feature = "quickcheck")]
 pub use quickcheck;

--- a/src/merkle_reg.rs
+++ b/src/merkle_reg.rs
@@ -2,7 +2,6 @@ use core::convert::Infallible;
 use core::fmt;
 use std::collections::{BTreeMap, BTreeSet};
 
-use quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
 use tiny_keccak::{Hasher, Sha3};
 
@@ -279,6 +278,10 @@ impl<T: AsRef<[u8]>> Sha3Hash for T {
     }
 }
 
+#[cfg(feature = "quickcheck")]
+use quickcheck::{Arbitrary, Gen};
+
+#[cfg(feature = "quickcheck")]
 impl<T: Arbitrary + Sha3Hash> Arbitrary for MerkleReg<T> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let mut reg = MerkleReg::new();

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -444,7 +444,6 @@ impl<M: Debug, A: Ord + Hash + Debug> Debug for Op<M, A> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate rand;
 
     #[test]
     // a bug found with rust quickcheck where deferred operations

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -8,7 +8,6 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use crate::ctx::{AddCtx, ReadCtx, RmCtx};
-use crate::quickcheck::{Arbitrary, Gen};
 use crate::{CmRDT, CvRDT, Dot, ResetRemove, VClock};
 
 /// `Orswot` is an add-biased or-set without tombstones ported from
@@ -366,6 +365,10 @@ impl<M: Hash + Clone + Eq, A: Ord + Hash + Clone> Orswot<M, A> {
     }
 }
 
+#[cfg(feature = "quickcheck")]
+use quickcheck::{Arbitrary, Gen};
+
+#[cfg(feature = "quickcheck")]
 impl<A: Ord + Hash + Arbitrary + Debug, M: Hash + Eq + Arbitrary> Arbitrary for Op<M, A> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let dot = Dot::arbitrary(g);

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -20,7 +20,6 @@ use std::collections::{btree_map, BTreeMap};
 
 use serde::{Deserialize, Serialize};
 
-use crate::quickcheck::{Arbitrary, Gen};
 use crate::{CmRDT, CvRDT, Dot, DotRange, ResetRemove};
 
 /// A `VClock` is a standard vector clock.
@@ -324,6 +323,10 @@ impl<A: Ord + Clone + Debug> From<Dot<A>> for VClock<A> {
     }
 }
 
+#[cfg(feature = "quickcheck")]
+use quickcheck::{Arbitrary, Gen};
+
+#[cfg(feature = "quickcheck")]
 impl<A: Ord + Clone + Debug + Arbitrary> Arbitrary for VClock<A> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let mut clock = VClock::default();

--- a/test/glist.rs
+++ b/test/glist.rs
@@ -103,7 +103,7 @@ fn prop_ops_are_associative(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>, ops_c: Vec<O
 
     // a * b
     let mut glist_ab = glist_a;
-    for op in ops_b.clone() {
+    for op in ops_b {
         assert!(glist_ab.validate_op(&op).is_ok());
         glist_ab.apply(op);
     }
@@ -135,11 +135,11 @@ fn prop_merge_commute(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>) {
     let mut glist_a = GList::new();
     let mut glist_b = GList::new();
 
-    for op in ops_a.clone() {
+    for op in ops_a {
         assert!(glist_a.validate_op(&op).is_ok());
         glist_a.apply(op)
     }
-    for op in ops_b.clone() {
+    for op in ops_b {
         assert!(glist_b.validate_op(&op).is_ok());
         glist_b.apply(op)
     }
@@ -157,7 +157,7 @@ fn prop_merge_associative(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>, ops_c: Vec<Op<
     let mut glist_b = GList::new();
     let mut glist_c = GList::new();
 
-    for op in ops_a.clone() {
+    for op in ops_a {
         assert!(glist_a.validate_op(&op).is_ok());
         glist_a.apply(op)
     }

--- a/test/map.rs
+++ b/test/map.rs
@@ -6,8 +6,9 @@ type TKey = u8;
 type TVal = MVReg<u8, TActor>;
 type TOp = map::Op<TKey, Map<TKey, TVal, TActor>, TActor>;
 type TMap = Map<TKey, Map<TKey, TVal, TActor>, TActor>;
+type OpMaterial = (u8, u8, u8, u8, u8);
 
-fn build_ops(prims: (u8, Vec<(u8, u8, u8, u8, u8)>)) -> (TActor, Vec<TOp>) {
+fn build_ops(prims: (u8, Vec<OpMaterial>)) -> (TActor, Vec<TOp>) {
     let (actor, ops_data) = prims;
 
     let mut ops = Vec::new();
@@ -577,8 +578,8 @@ fn apply_ops(map: &mut TMap, ops: &[TOp]) {
 quickcheck! {
     // TODO: add test to show equivalence of merge and Op exchange
     fn prop_op_exchange_same_as_merge(
-        ops1_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops2_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops1_prim: (u8, Vec<OpMaterial>),
+        ops2_prim: (u8, Vec<OpMaterial>)
     ) -> TestResult {
         let ops1 = build_ops(ops1_prim);
         let ops2 = build_ops(ops2_prim);
@@ -603,8 +604,8 @@ quickcheck! {
     }
 
     fn prop_op_exchange_converges(
-        ops1_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops2_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops1_prim: (u8, Vec<OpMaterial>),
+        ops2_prim: (u8, Vec<OpMaterial>)
     ) -> TestResult {
         let ops1 = build_ops(ops1_prim);
         let ops2 = build_ops(ops2_prim);
@@ -631,9 +632,9 @@ quickcheck! {
     }
 
     fn prop_op_exchange_associative(
-        ops1_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops2_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops3_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops1_prim: (u8, Vec<OpMaterial>),
+        ops2_prim: (u8, Vec<OpMaterial>),
+        ops3_prim: (u8, Vec<OpMaterial>)
     ) -> TestResult {
         let ops1 = build_ops(ops1_prim);
         let ops2 = build_ops(ops2_prim);
@@ -664,7 +665,7 @@ quickcheck! {
     }
 
     fn prop_op_idempotent(
-        ops_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops_prim: (u8, Vec<OpMaterial>)
     ) -> bool {
         let ops = build_ops(ops_prim);
         let mut m = TMap::new();
@@ -677,9 +678,9 @@ quickcheck! {
     }
 
     fn prop_op_associative(
-        ops1_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops2_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops3_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops1_prim: (u8, Vec<OpMaterial>),
+        ops2_prim: (u8, Vec<OpMaterial>),
+        ops3_prim: (u8, Vec<OpMaterial>)
     ) -> TestResult {
         let ops1 = build_ops(ops1_prim);
         let ops2 = build_ops(ops2_prim);
@@ -711,9 +712,9 @@ quickcheck! {
 
 
     fn prop_merge_associative(
-        ops1_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops2_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops3_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops1_prim: (u8, Vec<OpMaterial>),
+        ops2_prim: (u8, Vec<OpMaterial>),
+        ops3_prim: (u8, Vec<OpMaterial>)
     ) -> TestResult {
         let ops1 = build_ops(ops1_prim);
         let ops2 = build_ops(ops2_prim);
@@ -745,8 +746,8 @@ quickcheck! {
     }
 
     fn prop_merge_commutative(
-        ops1_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops2_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops1_prim: (u8, Vec<OpMaterial>),
+        ops2_prim: (u8, Vec<OpMaterial>)
     ) -> TestResult {
         let ops1 = build_ops(ops1_prim);
         let ops2 = build_ops(ops2_prim);
@@ -774,8 +775,8 @@ quickcheck! {
 
 
     fn prop_merge_followed_by_merge(
-        ops1_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops2_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops1_prim: (u8, Vec<OpMaterial>),
+        ops2_prim: (u8, Vec<OpMaterial>)
     ) -> TestResult {
         let ops1 = build_ops(ops1_prim);
         let ops2 = build_ops(ops2_prim);
@@ -801,7 +802,7 @@ quickcheck! {
     }
 
     fn prop_merge_idempotent(
-        ops_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops_prim: (u8, Vec<OpMaterial>)
     ) -> bool {
         let ops = build_ops(ops_prim);
 
@@ -817,7 +818,7 @@ quickcheck! {
     }
 
     fn prop_reset_remove_with_empty_vclock_is_nop(
-        ops_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops_prim: (u8, Vec<OpMaterial>)
     ) -> bool {
         let ops = build_ops(ops_prim);
 
@@ -831,7 +832,7 @@ quickcheck! {
     }
 
     fn prop_reset_remove_with_map_clock_is_empty_map(
-        ops_prim: (u8, Vec<(u8, u8, u8, u8, u8)>)
+        ops_prim: (u8, Vec<OpMaterial>)
     ) -> bool {
         let mut m = TMap::new();
         apply_ops(&mut m, &build_ops(ops_prim).1);
@@ -845,8 +846,8 @@ quickcheck! {
     }
 
     fn prop_reset_remove_than_merge_same_as_merge_than_reset_remove(
-        ops1_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
-        ops2_prim: (u8, Vec<(u8, u8, u8, u8, u8)>),
+        ops1_prim: (u8, Vec<OpMaterial>),
+        ops2_prim: (u8, Vec<OpMaterial>),
         vclock: VClock<u8>
     ) -> TestResult {
         let ops1 = build_ops(ops1_prim);

--- a/test/mvreg.rs
+++ b/test/mvreg.rs
@@ -115,7 +115,7 @@ fn ops_are_not_compatible(opss: &[&Vec<(u8, u8)>]) -> bool {
                 a_clock.apply(a_clock.inc(*a_actor));
                 b_clock.apply(b_clock.inc(*b_actor));
 
-                if b_clock.get(&a_actor) == a_clock.get(&a_actor) {
+                if b_clock.get(a_actor) == a_clock.get(a_actor) {
                     // this check is a bit broad as it's not a failure
                     // to insert the same value with the same actor version
                     // but for simplicity we reject those ops as well

--- a/test/orswot.rs
+++ b/test/orswot.rs
@@ -87,14 +87,14 @@ quickcheck! {
             let merged_members = merged.read().val;
 
             for ReadCtx { val, rm_clock, .. } in orswot_1.iter() {
-                if !merged_members.contains(&val) {
+                if !merged_members.contains(val) {
                     let mut val_clock = rm_clock.clone();
                     for op in ops_2.iter() {
                         match op {
                             Op::Rm { clock, .. } => val_clock.reset_remove(clock),
                             Op::Add { members, dot } => {
                                 if members.is_empty() {
-                                    val_clock.reset_remove(&dot.clone().into());
+                                    val_clock.reset_remove(&VClock::from(*dot));
                                 }
                             }
                         }
@@ -104,14 +104,14 @@ quickcheck! {
             }
 
             for ReadCtx { val, rm_clock, .. } in orswot_2.iter() {
-                if !merged_members.contains(&val) {
+                if !merged_members.contains(val) {
                     let mut val_clock = rm_clock.clone();
                     for op in ops_1.iter() {
                         match op {
                             Op::Rm { clock, .. } => val_clock.reset_remove(clock),
                             Op::Add { members, dot } => {
                                 if members.is_empty() {
-                                    val_clock.reset_remove(&dot.clone().into());
+                                    val_clock.reset_remove(&VClock::from(*dot));
                                 }
                             }
                         }
@@ -227,7 +227,7 @@ fn merge_clocks_of_identical_entries() {
     let mut final_clock = VClock::new();
     final_clock.apply(final_clock.inc("A"));
     final_clock.apply(final_clock.inc("B"));
-    assert_eq!(a.contains(&1).val, true);
+    assert!(a.contains(&1).val);
     assert_eq!(a.contains(&1).rm_clock, final_clock);
 }
 


### PR DESCRIPTION
three new feature flags:

- `quickcheck` -- enables Arbitrary implementations for use in external prop tests
- `num` -- for including CRDT's which rely on arbitrary-precision (i.e. glist, list, pncounter, gcounter)
- `merkle` -- for BFT crdts that rely on cryptographic hashes for security

We'll leave these all on by default and allow folks to disable those they don't care for