### PR TITLE
Add initial implementation and implementation of position_entries

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -185,7 +185,7 @@ impl<T, A: Ord + Clone> List<T, A> {
     /// assert_eq!(list.read_into::<Vec<_>>(), vec![1, 2, 3]);
     /// ```
     pub fn read_into<C: FromIterator<T>>(self) -> C {
-        self.seq.into_iter().map(|(_, v)| v).collect()
+        self.seq.into_values().collect()
     }
 
     /// Get the elements represented by the List.

--- a/src/list.rs
+++ b/src/list.rs
@@ -203,6 +203,13 @@ impl<T, A: Ord + Clone> List<T, A> {
         self.iter().nth(ix)
     }
 
+		/// Find an identifer by an index.
+		pub fn position_entry(&self, id: &Identifier<OrdDot<A>>) -> Option<usize> {
+			self.iter_entries()
+				.enumerate()
+				.find_map(|(ix, (ident, _))| if ident == id { Some (ix) } else { None })
+		}
+
     /// Finds an element by its Identifier.
     pub fn get(&self, id: &Identifier<OrdDot<A>>) -> Option<&T> {
         self.seq.get(id)

--- a/src/list.rs
+++ b/src/list.rs
@@ -203,12 +203,12 @@ impl<T, A: Ord + Clone> List<T, A> {
         self.iter().nth(ix)
     }
 
-		/// Find an identifer by an index.
-		pub fn position_entry(&self, id: &Identifier<OrdDot<A>>) -> Option<usize> {
-			self.iter_entries()
-				.enumerate()
-				.find_map(|(ix, (ident, _))| if ident == id { Some (ix) } else { None })
-		}
+    /// Find an identifer by an index.
+    pub fn position_entry(&self, id: &Identifier<OrdDot<A>>) -> Option<usize> {
+        self.iter_entries()
+            .enumerate()
+            .find_map(|(ix, (ident, _))| if ident == id { Some(ix) } else { None })
+    }
 
     /// Finds an element by its Identifier.
     pub fn get(&self, id: &Identifier<OrdDot<A>>) -> Option<&T> {

--- a/test/list.rs
+++ b/test/list.rs
@@ -177,7 +177,7 @@ fn test_identifier_position() {
     site1.apply(op_a.clone());
     let op_b = site1.append('b', 0);
     site1.apply(op_b.clone());
-		let op_c = site1.append('c', 0);
+    let op_c = site1.append('c', 0);
 
     assert_eq!(site1.position_entry(&op_a.id()), Some(0));
     assert_eq!(site1.position_entry(&op_b.id()), Some(1));

--- a/test/list.rs
+++ b/test/list.rs
@@ -171,6 +171,20 @@ fn test_position() {
 }
 
 #[test]
+fn test_identifier_position() {
+    let mut site1 = List::new();
+    let op_a = site1.append('a', 0);
+    site1.apply(op_a.clone());
+    let op_b = site1.append('b', 0);
+    site1.apply(op_b.clone());
+		let op_c = site1.append('c', 0);
+
+    assert_eq!(site1.position_entry(&op_a.id()), Some(0));
+    assert_eq!(site1.position_entry(&op_b.id()), Some(1));
+    assert_eq!(site1.position_entry(&op_c.id()), None);
+}
+
+#[test]
 fn test_reapply_list_ops() {
     let mut rng = rand::thread_rng();
 


### PR DESCRIPTION
This was the first way that compiled immediately, but this is certainly an `O(n)` solution. Perhaps there is a better way to do this which is faster at larger sizes.