### PR TITLE
Drusu/resolve debian build failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ tiny-keccak = { version = "2.0.2", features = ["sha3"], optional = true }
 quickcheck = { version = "1.0", optional = true }
 
 [dev-dependencies]
-crdts = { path = ".", features = ["quickcheck"] }
 quickcheck_macros = "1.0"
 derive_more = "0.99"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crdts"
 description = "Practical, serializable, thoroughly tested CRDTs"
-version = "7.3.1"
+version = "7.3.2"
 authors = ["Tyler Neely <t@jujit.su>", "David Rusu <davidrusu.me@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-crdt/rust-crdt"

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -147,7 +147,7 @@ impl<A: fmt::Debug> fmt::Display for DotRange<A> {
 
 impl<A: fmt::Debug> std::error::Error for DotRange<A> {}
 
-#[cfg(test)]
+#[cfg(all(test, feature = "quickcheck"))]
 mod test {
     use super::*;
     use quickcheck_macros::quickcheck;

--- a/test/glist.rs
+++ b/test/glist.rs
@@ -2,7 +2,6 @@ use num::BigRational;
 
 use crdts::glist::{GList, Op};
 use crdts::{CmRDT, CvRDT, Identifier};
-use quickcheck_macros::quickcheck;
 
 #[test]
 fn test_concurrent_inserts_with_same_identifier_can_be_split() {
@@ -56,162 +55,168 @@ fn test_insert_at_front() {
     assert_eq!(vec![&1, &0], glist.read::<Vec<_>>());
 }
 
-#[quickcheck]
-fn prop_ops_commute(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>) {
-    let mut glist_a = GList::new();
-    let mut glist_b = GList::new();
+#[cfg(feature = "quickcheck")]
+mod prop_tests {
+    use super::*;
+    use quickcheck_macros::quickcheck;
 
-    for op in ops_a.clone() {
-        assert!(glist_a.validate_op(&op).is_ok());
-        glist_a.apply(op)
-    }
-    for op in ops_b.clone() {
-        assert!(glist_b.validate_op(&op).is_ok());
-        glist_b.apply(op)
-    }
-    // Deliver the ops to each other
-    for op in ops_a {
-        assert!(glist_b.validate_op(&op).is_ok());
-        glist_b.apply(op)
-    }
-    for op in ops_b {
-        assert!(glist_a.validate_op(&op).is_ok());
-        glist_a.apply(op)
-    }
+    #[quickcheck]
+    fn prop_ops_commute(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>) {
+        let mut glist_a = GList::new();
+        let mut glist_b = GList::new();
 
-    assert_eq!(glist_a, glist_b);
-}
+        for op in ops_a.clone() {
+            assert!(glist_a.validate_op(&op).is_ok());
+            glist_a.apply(op)
+        }
+        for op in ops_b.clone() {
+            assert!(glist_b.validate_op(&op).is_ok());
+            glist_b.apply(op)
+        }
+        // Deliver the ops to each other
+        for op in ops_a {
+            assert!(glist_b.validate_op(&op).is_ok());
+            glist_b.apply(op)
+        }
+        for op in ops_b {
+            assert!(glist_a.validate_op(&op).is_ok());
+            glist_a.apply(op)
+        }
 
-#[quickcheck]
-fn prop_ops_are_associative(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>, ops_c: Vec<Op<u8>>) {
-    let mut glist_a = GList::new();
-    let mut glist_b = GList::new();
-    let mut glist_c = GList::new();
-
-    for op in ops_a.clone() {
-        assert!(glist_a.validate_op(&op).is_ok());
-        glist_a.apply(op);
-    }
-    for op in ops_b.clone() {
-        assert!(glist_b.validate_op(&op).is_ok());
-        glist_b.apply(op);
-    }
-    for op in ops_c.clone() {
-        assert!(glist_c.validate_op(&op).is_ok());
-        glist_c.apply(op);
+        assert_eq!(glist_a, glist_b);
     }
 
-    // a * b
-    let mut glist_ab = glist_a;
-    for op in ops_b {
-        assert!(glist_ab.validate_op(&op).is_ok());
-        glist_ab.apply(op);
+    #[quickcheck]
+    fn prop_ops_are_associative(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>, ops_c: Vec<Op<u8>>) {
+        let mut glist_a = GList::new();
+        let mut glist_b = GList::new();
+        let mut glist_c = GList::new();
+
+        for op in ops_a.clone() {
+            assert!(glist_a.validate_op(&op).is_ok());
+            glist_a.apply(op);
+        }
+        for op in ops_b.clone() {
+            assert!(glist_b.validate_op(&op).is_ok());
+            glist_b.apply(op);
+        }
+        for op in ops_c.clone() {
+            assert!(glist_c.validate_op(&op).is_ok());
+            glist_c.apply(op);
+        }
+
+        // a * b
+        let mut glist_ab = glist_a;
+        for op in ops_b {
+            assert!(glist_ab.validate_op(&op).is_ok());
+            glist_ab.apply(op);
+        }
+
+        // b * c
+        let mut glist_bc = glist_b;
+        for op in ops_c.clone() {
+            assert!(glist_bc.validate_op(&op).is_ok());
+            glist_bc.apply(op);
+        }
+
+        // (a * b) * c
+        for op in ops_c {
+            assert!(glist_ab.validate_op(&op).is_ok());
+            glist_ab.apply(op)
+        }
+
+        // a * (b * c)
+        for op in ops_a {
+            assert!(glist_bc.validate_op(&op).is_ok());
+            glist_bc.apply(op)
+        }
+
+        assert_eq!(glist_ab, glist_bc);
     }
 
-    // b * c
-    let mut glist_bc = glist_b;
-    for op in ops_c.clone() {
-        assert!(glist_bc.validate_op(&op).is_ok());
-        glist_bc.apply(op);
+    #[quickcheck]
+    fn prop_merge_commute(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>) {
+        let mut glist_a = GList::new();
+        let mut glist_b = GList::new();
+
+        for op in ops_a {
+            assert!(glist_a.validate_op(&op).is_ok());
+            glist_a.apply(op)
+        }
+        for op in ops_b {
+            assert!(glist_b.validate_op(&op).is_ok());
+            glist_b.apply(op)
+        }
+
+        let glist_a_snapshot = glist_a.clone();
+        glist_a.merge(glist_b.clone());
+        glist_b.merge(glist_a_snapshot);
+
+        assert_eq!(glist_a, glist_b);
     }
 
-    // (a * b) * c
-    for op in ops_c {
-        assert!(glist_ab.validate_op(&op).is_ok());
-        glist_ab.apply(op)
+    #[quickcheck]
+    fn prop_merge_associative(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>, ops_c: Vec<Op<u8>>) {
+        let mut glist_a = GList::new();
+        let mut glist_b = GList::new();
+        let mut glist_c = GList::new();
+
+        for op in ops_a {
+            assert!(glist_a.validate_op(&op).is_ok());
+            glist_a.apply(op)
+        }
+        for op in ops_b {
+            assert!(glist_b.validate_op(&op).is_ok());
+            glist_b.apply(op)
+        }
+        for op in ops_c {
+            assert!(glist_c.validate_op(&op).is_ok());
+            glist_c.apply(op)
+        }
+
+        // (a * b) * c
+        let mut glist_ab_first = glist_a.clone();
+        glist_ab_first.merge(glist_b.clone());
+        glist_ab_first.merge(glist_c.clone());
+
+        // a * (b * c)
+        let mut glist_bc_first = glist_b;
+        glist_bc_first.merge(glist_c);
+        glist_bc_first.merge(glist_a);
+
+        assert_eq!(glist_ab_first, glist_bc_first);
     }
 
-    // a * (b * c)
-    for op in ops_a {
-        assert!(glist_bc.validate_op(&op).is_ok());
-        glist_bc.apply(op)
-    }
+    #[quickcheck]
+    fn prop_validate_against_vec_model(plan: Vec<(usize, u8, bool)>) {
+        let mut model: Vec<u8> = Default::default();
+        let mut glist: GList<u8> = Default::default();
 
-    assert_eq!(glist_ab, glist_bc);
-}
-
-#[quickcheck]
-fn prop_merge_commute(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>) {
-    let mut glist_a = GList::new();
-    let mut glist_b = GList::new();
-
-    for op in ops_a {
-        assert!(glist_a.validate_op(&op).is_ok());
-        glist_a.apply(op)
-    }
-    for op in ops_b {
-        assert!(glist_b.validate_op(&op).is_ok());
-        glist_b.apply(op)
-    }
-
-    let glist_a_snapshot = glist_a.clone();
-    glist_a.merge(glist_b.clone());
-    glist_b.merge(glist_a_snapshot);
-
-    assert_eq!(glist_a, glist_b);
-}
-
-#[quickcheck]
-fn prop_merge_associative(ops_a: Vec<Op<u8>>, ops_b: Vec<Op<u8>>, ops_c: Vec<Op<u8>>) {
-    let mut glist_a = GList::new();
-    let mut glist_b = GList::new();
-    let mut glist_c = GList::new();
-
-    for op in ops_a {
-        assert!(glist_a.validate_op(&op).is_ok());
-        glist_a.apply(op)
-    }
-    for op in ops_b {
-        assert!(glist_b.validate_op(&op).is_ok());
-        glist_b.apply(op)
-    }
-    for op in ops_c {
-        assert!(glist_c.validate_op(&op).is_ok());
-        glist_c.apply(op)
-    }
-
-    // (a * b) * c
-    let mut glist_ab_first = glist_a.clone();
-    glist_ab_first.merge(glist_b.clone());
-    glist_ab_first.merge(glist_c.clone());
-
-    // a * (b * c)
-    let mut glist_bc_first = glist_b;
-    glist_bc_first.merge(glist_c);
-    glist_bc_first.merge(glist_a);
-
-    assert_eq!(glist_ab_first, glist_bc_first);
-}
-
-#[quickcheck]
-fn prop_validate_against_vec_model(plan: Vec<(usize, u8, bool)>) {
-    let mut model: Vec<u8> = Default::default();
-    let mut glist: GList<u8> = Default::default();
-
-    for mut instruction in plan {
-        instruction.0 = if !glist.is_empty() {
-            instruction.0 % glist.len()
-        } else {
-            0
-        };
-        match instruction {
-            (index, elem, true) => {
-                // insert before
-                model.insert(index, elem);
-                let op = glist.insert_before(glist.get(index), elem);
-                glist.apply(op);
-            }
-            (index, elem, false) => {
-                // insert after
-                if index + 1 == model.len() || model.is_empty() {
-                    model.push(elem)
-                } else {
-                    model.insert(index + 1, elem);
+        for mut instruction in plan {
+            instruction.0 = if !glist.is_empty() {
+                instruction.0 % glist.len()
+            } else {
+                0
+            };
+            match instruction {
+                (index, elem, true) => {
+                    // insert before
+                    model.insert(index, elem);
+                    let op = glist.insert_before(glist.get(index), elem);
+                    glist.apply(op);
                 }
-                let op = glist.insert_after(glist.get(index), elem);
-                glist.apply(op);
+                (index, elem, false) => {
+                    // insert after
+                    if index + 1 == model.len() || model.is_empty() {
+                        model.push(elem)
+                    } else {
+                        model.insert(index + 1, elem);
+                    }
+                    let op = glist.insert_after(glist.get(index), elem);
+                    glist.apply(op);
+                }
             }
         }
+        assert_eq!(model, glist.read_into::<Vec<u8>>());
     }
-    assert_eq!(model, glist.read_into::<Vec<u8>>());
 }

--- a/test/glist.rs
+++ b/test/glist.rs
@@ -1,7 +1,7 @@
 use num::BigRational;
 
-use crdts::glist::{GList, Op};
-use crdts::{CmRDT, CvRDT, Identifier};
+use crdts::glist::GList;
+use crdts::{CmRDT, Identifier};
 
 #[test]
 fn test_concurrent_inserts_with_same_identifier_can_be_split() {
@@ -58,6 +58,7 @@ fn test_insert_at_front() {
 #[cfg(feature = "quickcheck")]
 mod prop_tests {
     use super::*;
+    use crdts::{glist::Op, CvRDT};
     use quickcheck_macros::quickcheck;
 
     #[quickcheck]

--- a/test/list.rs
+++ b/test/list.rs
@@ -1,7 +1,7 @@
-use crdts::list::{List, Op};
+use crdts::list::List;
 use crdts::CmRDT;
 use rand::distributions::Alphanumeric;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 
 type SiteId = u32;
 
@@ -277,8 +277,10 @@ fn test_deep_inserts() {
 #[cfg(feature = "quickcheck")]
 mod prop_tests {
     use super::*;
+    use crdts::list::Op;
     use quickcheck::{Arbitrary, Gen};
     use quickcheck_macros::quickcheck;
+    use rand::SeedableRng;
 
     #[derive(Debug, Clone)]
     struct OperationList(pub Vec<Op<char, SiteId>>);

--- a/test/merkle_reg.rs
+++ b/test/merkle_reg.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use crdts::merkle_reg::{Hash, MerkleReg, Node};
+use crdts::merkle_reg::MerkleReg;
 use crdts::CmRDT;
 
 #[test]
@@ -107,7 +107,10 @@ fn test_orphaned_nodes_grows_if_ops_are_applied_backwards() {
 #[cfg(feature = "quickcheck")]
 mod prop_tests {
     use super::*;
-    use crdts::CvRDT;
+    use crdts::{
+        merkle_reg::{Hash, Node},
+        CvRDT,
+    };
     use quickcheck_macros::quickcheck;
 
     #[quickcheck]

--- a/test/orswot.rs
+++ b/test/orswot.rs
@@ -209,6 +209,7 @@ fn test_reset_remove_semantics() {
 #[cfg(feature = "quickcheck")]
 mod prop_tests {
     use super::*;
+    use crdts::{ctx::ReadCtx, DotRange, ResetRemove};
     use quickcheck_macros::quickcheck;
 
     type Actor = u8;

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,11 +1,9 @@
-#[macro_use]
-extern crate quickcheck;
-
-extern crate crdts;
-
+#[cfg(feature = "num")]
 mod glist;
+#[cfg(feature = "num")]
 mod list;
 mod map;
+#[cfg(feature = "merkle")]
 mod merkle_reg;
 mod mvreg;
 mod orswot;


### PR DESCRIPTION
resolves #136

Main change is to restructures tests to put prop tests within a prop_tests module so that we can compile them out when `quickcheck` is disabled